### PR TITLE
fix: pin scorecard action commit

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
     steps:
       - name: OpenSSF Scorecard
-        uses: ossf/scorecard-action@ff5dd8929f96a8a4dc67d13f32b8c75057829621 # v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Fix OpenSSF Scorecard publishing by pinning ossf/scorecard-action to the peeled commit SHA for v2.4.0 instead of the annotated tag object SHA.\n\nLocal gates passed:\n- uv run python scripts/run_ci_checks.py lint\n- uv run ai-repo-safety scan --target .\n- uv run ai-repo-safety prepush --target .