### PR TITLE
fix: pin scorecard sarif upload action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,6 +23,6 @@ jobs:
           results_format: sarif
           publish_results: true
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@b0c4fd77f6c559021d78430ec4d0d169ae74a4eb # v3
+        uses: github/codeql-action/upload-sarif@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Fix OpenSSF Scorecard workflow verification by pinning github/codeql-action/upload-sarif to the peeled commit SHA for v3 instead of the annotated tag object SHA.\n\nLocal gates passed:\n- uv run python scripts/run_ci_checks.py lint\n- uv run ai-repo-safety scan --target .\n- uv run ai-repo-safety prepush --target .