### PR TITLE
fix: scope captcha solver budgets per detail

### DIFF
--- a/job_ftch/config/site_parsers.yaml
+++ b/job_ftch/config/site_parsers.yaml
@@ -231,7 +231,7 @@ parsers:
     wait: "domcontentloaded"
     include_if_detail_page: false
   - name: protected_browser_defaults
-    domain_pattern: "^https?://(?:himalayas\\.app|(?:www\\.)?foody\\.com\\.cy|(?:www\\.)?fishingbooker\\.com|theprotocol\\.it|(?:www\\.)?pracuj\\.pl|(?:www\\.)?cypruswork\\.com)(?:/|$)"
+    domain_pattern: "^https?://(?:himalayas\\.app|(?:www\\.)?foody\\.com\\.cy|(?:www\\.)?fishingbooker\\.com|theprotocol\\.it|(?:www\\.)?pracuj\\.pl|(?:www\\.)?cypruswork\\.com|jobs\\.ashbyhq\\.com|careers\\.higgsfield\\.kz|job\\.beeline\\.ru)(?:/|$)"
     has_custom_parse: false
     supports_discover: false
     render: true
@@ -248,6 +248,14 @@ parsers:
       protected_hint: "waf_challenge"
       wait_fallback: "load"
       settle_seconds: 5
+      captcha_authorized_domains:
+        - jobs.ashbyhq.com
+        - careers.higgsfield.kz
+        - job.beeline.ru
+      proxy_rescue_allow_domains:
+        - jobs.ashbyhq.com
+        - careers.higgsfield.kz
+        - job.beeline.ru
   - name: rabota_by
     domain_pattern: "^https?://([a-z0-9-]+\\.)?rabota\\.by(?:/|$)"
     has_custom_parse: true

--- a/job_ftch/infrastructure/bypass/captcha_solver.py
+++ b/job_ftch/infrastructure/bypass/captcha_solver.py
@@ -149,14 +149,16 @@ class CaptchaSolverBypass:
         self._cookie_cache: dict[str, _CookieCache] = {}
         self._max_attempts = max(1, max_attempts)
         self._max_paid_attempts = max(0, max_paid_attempts)
-        self._attempts = 0
-        self._paid_attempts = 0
+        # ponytail: per-detail budget keeps one blocked card from poisoning
+        # sibling cards; a source-wide quota remains runtime policy.
+        self._attempts: dict[tuple[str, str, str], int] = {}
+        self._paid_attempts: dict[tuple[str, str, str], int] = {}
         self._min_provider_seconds = max(0.0, min_provider_seconds)
         self._paid_lock = asyncio.Lock()
         self._proxy_url = proxy_url
         self._provider_routes = provider_routes or {}
         self._backoff_seconds = max(0.0, backoff_seconds)
-        self._failure_backoff: dict[tuple[str, str], float] = {}
+        self._failure_backoff: dict[tuple[str, str, str], float] = {}
 
     async def apply_http(self, client: Any) -> Any:
         return client
@@ -207,7 +209,9 @@ class CaptchaSolverBypass:
             parsed_page_url = urlparse(str(page.url))
             domain = (parsed_page_url.hostname or parsed_page_url.netloc).lower()
         normalized_type = normalize_challenge_type(challenge_type)
-        backoff_key = (domain, normalized_type)
+        request_url = url or str(getattr(page, "url", ""))
+        attempt_key = self._attempt_key(domain, normalized_type, request_url)
+        backoff_key = attempt_key
         backoff_until = self._failure_backoff.get(backoff_key)
         if domain and backoff_until and backoff_until > time.monotonic():
             return CaptchaSolveResult(
@@ -230,7 +234,7 @@ class CaptchaSolverBypass:
                 result_kind=CaptchaResultKind.SESSION,
             )
 
-        if self._attempts >= self._max_attempts:
+        if self._attempts.get(attempt_key, 0) >= self._max_attempts:
             return CaptchaSolveResult(
                 solved=False,
                 method=self._provider,
@@ -238,7 +242,7 @@ class CaptchaSolverBypass:
                 failure_reason=CaptchaFailureReason.BUDGET_EXHAUSTED,
                 challenge_type=normalized_type,
             )
-        self._attempts += 1
+        self._attempts[attempt_key] = self._attempts.get(attempt_key, 0) + 1
 
         provider_authorized = self._domain_authorized(domain)
         provider_chain = self._provider_chain_for(challenge_type)
@@ -254,7 +258,9 @@ class CaptchaSolverBypass:
                 )
             provider_chain = filtered
         if provider_chain:
-            result = await self._solve_provider_chain(page, challenge_type, url, provider_chain)
+            result = await self._solve_provider_chain(
+                page, challenge_type, url, provider_chain, attempt_key
+            )
         elif self._provider == "browser_wait":
             result = await self._solve_browser_wait(page, challenge_type)
         elif not provider_authorized:
@@ -290,18 +296,21 @@ class CaptchaSolverBypass:
                     failure_reason=CaptchaFailureReason.DEADLINE_INSUFFICIENT,
                     challenge_type=normalized_type,
                 )
-            elif self._paid_attempts >= self._max_paid_attempts:
-                result = CaptchaSolveResult(
-                    solved=False,
-                    method=self._provider,
-                    error="paid solver budget exhausted",
-                    failure_reason=CaptchaFailureReason.BUDGET_EXHAUSTED,
-                    challenge_type=normalized_type,
-                )
             else:
                 async with self._paid_lock:
-                    self._paid_attempts += 1
-                    result = await self._solve_external_api(page, challenge_type, url)
+                    if self._paid_attempts.get(attempt_key, 0) >= self._max_paid_attempts:
+                        result = CaptchaSolveResult(
+                            solved=False,
+                            method=self._provider,
+                            error="paid solver budget exhausted",
+                            failure_reason=CaptchaFailureReason.BUDGET_EXHAUSTED,
+                            challenge_type=normalized_type,
+                        )
+                    else:
+                        self._paid_attempts[attempt_key] = (
+                            self._paid_attempts.get(attempt_key, 0) + 1
+                        )
+                        result = await self._solve_external_api(page, challenge_type, url)
         if result.solved and result.tokens:
             token = result.tokens.get("captcha_token", "")
             if token and not await self._inject_token(page, challenge_type, token):
@@ -382,12 +391,23 @@ class CaptchaSolverBypass:
         providers = self._provider_routes.get(normalized) or self._provider_routes.get("unknown")
         return tuple(providers or ())
 
+    @staticmethod
+    def _attempt_key(
+        domain: str,
+        challenge_type: str,
+        url: str,
+    ) -> tuple[str, str, str]:
+        from urllib.parse import urlparse
+
+        return domain, challenge_type, urlparse(url).path or "/"
+
     async def _solve_provider_chain(
         self,
         page: Any,
         challenge_type: str,
         url: str,
         provider_chain: tuple[str, ...],
+        attempt_key: tuple[str, str, str],
     ) -> CaptchaSolveResult:
         failures: list[str] = []
         for provider_name in provider_chain:
@@ -430,22 +450,25 @@ class CaptchaSolverBypass:
                             failure_reason=CaptchaFailureReason.DEADLINE_INSUFFICIENT,
                             challenge_type=normalize_challenge_type(challenge_type),
                         )
-                    elif self._paid_attempts >= self._max_paid_attempts:
-                        result = CaptchaSolveResult(
-                            solved=False,
-                            method=provider_name,
-                            error="paid solver budget exhausted",
-                            failure_reason=CaptchaFailureReason.BUDGET_EXHAUSTED,
-                            challenge_type=normalize_challenge_type(challenge_type),
-                        )
                     else:
                         async with self._paid_lock:
-                            self._paid_attempts += 1
-                            result = await self._solve_external_api(
-                                page,
-                                challenge_type,
-                                url,
-                            )
+                            if self._paid_attempts.get(attempt_key, 0) >= self._max_paid_attempts:
+                                result = CaptchaSolveResult(
+                                    solved=False,
+                                    method=provider_name,
+                                    error="paid solver budget exhausted",
+                                    failure_reason=CaptchaFailureReason.BUDGET_EXHAUSTED,
+                                    challenge_type=normalize_challenge_type(challenge_type),
+                                )
+                            else:
+                                self._paid_attempts[attempt_key] = (
+                                    self._paid_attempts.get(attempt_key, 0) + 1
+                                )
+                                result = await self._solve_external_api(
+                                    page,
+                                    challenge_type,
+                                    url,
+                                )
             finally:
                 self._provider = previous_provider
                 self._api_key = previous_api_key

--- a/job_ftch/infrastructure/sources/career_site_source.py
+++ b/job_ftch/infrastructure/sources/career_site_source.py
@@ -805,9 +805,10 @@ class CareerSiteSource(Source["RawItem"]):
 
         initial_bypass = self.spec.bypass or "auto"
         bypass_config = dict(self.spec.bypass_config)
-        parser_proxy_domains = self.spec.monitor_config.get("proxy_rescue_allow_domains")
-        if parser_proxy_domains:
-            bypass_config["proxy_rescue_allow_domains"] = parser_proxy_domains
+        for config_key in ("proxy_rescue_allow_domains", "captcha_authorized_domains"):
+            parser_domains = self.spec.monitor_config.get(config_key)
+            if parser_domains:
+                bypass_config[config_key] = parser_domains
         self.bypass_strategy = resolve_bypass(initial_bypass, bypass_config)
         cached_bypass = cached_strategy.get("bypass") if cached_strategy else None
         if (

--- a/job_ftch/infrastructure/sources/site_parsers/protected_defaults.py
+++ b/job_ftch/infrastructure/sources/site_parsers/protected_defaults.py
@@ -27,7 +27,10 @@ _DOMAIN_PATTERN = (
     r"(?:www\.)?fishingbooker\.com|"
     r"theprotocol\.it|"
     r"(?:www\.)?pracuj\.pl|"
-    r"(?:www\.)?cypruswork\.com"
+    r"(?:www\.)?cypruswork\.com|"
+    r"jobs\.ashbyhq\.com|"
+    r"careers\.higgsfield\.kz|"
+    r"job\.beeline\.ru"
     r")(?:/|$)"
 )
 
@@ -53,6 +56,16 @@ class ProtectedBrowserDefaultsParser:
                 "protected_hint": "waf_challenge",
                 "wait_fallback": "load",
                 "settle_seconds": 5,
+                "captcha_authorized_domains": [
+                    "jobs.ashbyhq.com",
+                    "careers.higgsfield.kz",
+                    "job.beeline.ru",
+                ],
+                "proxy_rescue_allow_domains": [
+                    "jobs.ashbyhq.com",
+                    "careers.higgsfield.kz",
+                    "job.beeline.ru",
+                ],
             },
         )
 

--- a/job_ftch/infrastructure/sources/site_parsers/superjob.py
+++ b/job_ftch/infrastructure/sources/site_parsers/superjob.py
@@ -23,6 +23,10 @@ class SuperJobRuParser:
         return SiteRuntimeDefaults(
             url_filter=r"superjob\.ru/vakansii/[a-z0-9-]+-\d+\.html$",
             include_if_detail_page=False,
+            extra={
+                "captcha_authorized_domains": ["www.superjob.ru", "superjob.ru"],
+                "proxy_rescue_allow_domains": ["www.superjob.ru", "superjob.ru"],
+            },
         )
 
     def parser_kind(self, url: str) -> None:

--- a/tests/infrastructure/bypass/test_captcha_workflow.py
+++ b/tests/infrastructure/bypass/test_captcha_workflow.py
@@ -575,6 +575,44 @@ async def test_solver_attempt_budget_is_enforced() -> None:
 
 
 @pytest.mark.asyncio
+async def test_solver_budget_allows_independent_detail_challenge() -> None:
+    solver = CaptchaSolverBypass(
+        provider="capsolver",
+        api_key="offline-key",  # pragma: allowlist secret
+        max_attempts=1,
+        max_paid_attempts=1,
+        min_provider_seconds=0,
+        enabled_providers=frozenset({"capsolver"}),
+    )
+    calls = 0
+
+    async def fake_external(*args: object, **kwargs: object) -> CaptchaSolveResult:
+        nonlocal calls
+        del args, kwargs
+        calls += 1
+        return CaptchaSolveResult(
+            solved=False,
+            method="capsolver",
+            failure_reason=CaptchaFailureReason.PROVIDER_REJECTED,
+        )
+
+    solver._solve_external_api = fake_external  # type: ignore[method-assign]
+
+    first = await solver.solve(
+        SimpleNamespace(url="https://example.test/jobs/one"),
+        challenge_type="hcaptcha",
+    )
+    second = await solver.solve(
+        SimpleNamespace(url="https://example.test/jobs/two"),
+        challenge_type="hcaptcha",
+    )
+
+    assert first.failure_reason is CaptchaFailureReason.PROVIDER_REJECTED
+    assert second.failure_reason is CaptchaFailureReason.PROVIDER_REJECTED
+    assert calls == 2
+
+
+@pytest.mark.asyncio
 async def test_paid_provider_is_rejected_when_deadline_is_too_short() -> None:
     solver = CaptchaSolverBypass(
         provider="capsolver",

--- a/tests/test_career_site_generic.py
+++ b/tests/test_career_site_generic.py
@@ -932,6 +932,38 @@ async def test_monitor_receives_runtime_bypass_strategy(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_parser_captcha_allowlist_reaches_bypass_config(monkeypatch):
+    captured = {}
+
+    def fake_resolve(name, bypass_config=None):
+        captured["name"] = name
+        captured["config"] = bypass_config
+        return SimpleNamespace()
+
+    monkeypatch.setattr(
+        "job_ftch.infrastructure.sources.career_site_source.resolve_bypass",
+        fake_resolve,
+    )
+    source = CareerSiteSource(
+        spec=CareerSiteSpec(
+            url="https://jobs.ashbyhq.com/example",
+            monitor_config={
+                "captcha_authorized_domains": ["jobs.ashbyhq.com"],
+                "proxy_rescue_allow_domains": ["jobs.ashbyhq.com"],
+            },
+        ),
+        http_client=object(),
+        auth=MagicMock(),
+    )
+
+    await source._init_strategy()
+
+    assert captured["name"] == "auto"
+    assert captured["config"]["captcha_authorized_domains"] == ["jobs.ashbyhq.com"]
+    assert captured["config"]["proxy_rescue_allow_domains"] == ["jobs.ashbyhq.com"]
+
+
+@pytest.mark.asyncio
 async def test_monitor_config_can_select_monitor(monkeypatch):
     spec = CareerSiteSpec(
         type="career_site",

--- a/tests/test_site_defaults.py
+++ b/tests/test_site_defaults.py
@@ -121,6 +121,29 @@ async def test_generic_source_defaults_exclude_geekjob_and_superjob_listing_page
     assert superjob.url_filter == r"superjob\.ru/vakansii/[a-z0-9-]+-\d+\.html$"
 
 
+def test_protected_parser_defaults_declare_only_authorized_domains() -> None:
+    from job_ftch.infrastructure.sources.site_defaults import apply_runtime_defaults
+
+    for url in (
+        "https://jobs.ashbyhq.com/example",
+        "https://careers.higgsfield.kz/",
+        "https://job.beeline.ru/vacancies",
+    ):
+        config = apply_runtime_defaults(CareerSiteSpec(url=url)).monitor_config
+        assert config["captcha_authorized_domains"] == [
+            "jobs.ashbyhq.com",
+            "careers.higgsfield.kz",
+            "job.beeline.ru",
+        ]
+        assert config["proxy_rescue_allow_domains"] == config["captcha_authorized_domains"]
+
+    superjob = apply_runtime_defaults(CareerSiteSpec(url="https://www.superjob.ru/vakansii/"))
+    assert superjob.monitor_config["captcha_authorized_domains"] == [
+        "www.superjob.ru",
+        "superjob.ru",
+    ]
+
+
 @pytest.mark.asyncio
 async def test_career_site_source_uses_tbank_root_defaults_for_one_level_expansion(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- pass parser-declared CAPTCHA and proxy rescue allowlists into source bypass configuration
- authorize only the required protected domains
- scope solver attempts and backoff by domain, challenge type, and detail URL
- add regression coverage

## Verification
- just code-verify
- uv run ai-repo-safety scan --target .
- uv run ai-repo-safety prepush --target .
- CAPTCHA workflow: 56 passed
- career/proxy targeted tests: 98 passed