### PR TITLE
fix: configure active superjob source

### DIFF
--- a/config/recipes/production_pipeline_recipe.yaml
+++ b/config/recipes/production_pipeline_recipe.yaml
@@ -113,7 +113,7 @@ live_run:
     --report-path artifacts/release/prod_run_live_17_clean_YYYYMMDD.json
   local_postgres_note: source preparation is intentionally serialized in prod/dev runtime to avoid host-to-docker asyncpg connect timeouts on local Postgres.
   sources_fixture: fixtures/sources/ai_jobs.json
-  sources_fixture_sha256: 4102fcb84e9cf40855a1879eb002f22912710db796b95dd0be4615e07e2e0ec2  # pragma: allowlist secret -- sources fixture content hash
+  sources_fixture_sha256: ca4fe8fed1ea7c8568690d3010116f3e804e7d0356e18ca6bd0dde4e507cd07f  # pragma: allowlist secret -- sources fixture content hash
   source_count: 17
   source_ids:
     - career_site:avito_careers

--- a/fixtures/bootstrap/tenant_ai_jobs.yaml
+++ b/fixtures/bootstrap/tenant_ai_jobs.yaml
@@ -48,6 +48,13 @@ sources:
     url: https://www.superjob.ru/vacancy/search/
     source_name: superjob_ru
     limit: 50
+    bypass: cloak
+    monitor: dom
+    monitor_config:
+      render: true
+      wait: domcontentloaded
+      settle_seconds: 1
+      url_filter: "www\\.superjob\\.ru/vakansii/[^/?#]+-\\d+\\.html$"
   - type: career_site
     url: https://rabota.sber.ru/search
     source_name: rabota_sber_ru

--- a/fixtures/sources/ai_jobs.json
+++ b/fixtures/sources/ai_jobs.json
@@ -10,7 +10,7 @@
     {"type": "career_site", "url": "https://hh.ru/search/vacancy",             "source_name": "hh_ru",          "limit": 50},
     {"type": "career_site", "url": "https://hh.kz/search/vacancy",             "source_name": "hh_kz",          "limit": 50},
     {"type": "career_site", "url": "https://yandex.ru/jobs/vacancies",         "source_name": "yandex_jobs",    "limit": 50},
-    {"type": "career_site", "url": "https://www.superjob.ru/vacancy/search/",  "source_name": "superjob_ru",    "limit": 50},
+    {"type": "career_site", "url": "https://www.superjob.ru/vacancy/search/",  "source_name": "superjob_ru",    "limit": 50, "bypass": "cloak", "monitor": "dom", "monitor_config": {"render": true, "wait": "domcontentloaded", "settle_seconds": 1, "url_filter": "www\\.superjob\\.ru/vakansii/[^/?#]+-\\d+\\.html$"}},
     {"type": "career_site", "url": "https://rabota.sber.ru/search",            "source_name": "rabota_sber_ru", "limit": 50},
     {"type": "career_site", "url": "https://www.tbank.ru/career/vacancies/it/","source_name": "tbank_it",       "limit": 50},
     {"type": "career_site", "url": "https://team.vk.company/vacancy/",         "source_name": "vk_careers",     "limit": 50},

--- a/job_ftch/adapters/telegram_bot/config/tenants/ai_jobs.yaml
+++ b/job_ftch/adapters/telegram_bot/config/tenants/ai_jobs.yaml
@@ -53,6 +53,13 @@ sources:
     url: https://www.superjob.ru/vacancy/search/
     source_name: superjob_ru
     limit: 50
+    bypass: cloak
+    monitor: dom
+    monitor_config:
+      render: true
+      wait: domcontentloaded
+      settle_seconds: 1
+      url_filter: "www\\.superjob\\.ru/vakansii/[^/?#]+-\\d+\\.html$"
   - type: career_site
     url: https://rabota.sber.ru/search
     source_name: rabota_sber_ru

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "job-ftch"
-version = "0.0.12"
+version = "0.0.13"
 description = "Open-source async pipeline for ingesting AI/tech job vacancies from Telegram and career sites"
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -2195,7 +2195,7 @@ wheels = [
 
 [[package]]
 name = "job-ftch"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
Apply the authorized cloak/dom runtime settings directly to the active base SuperJob source so the production tenant uses them on every process start.