### PR TITLE
chore: promote source runtime reliability to main

### DIFF
--- a/docker/runtime/Dockerfile.dev
+++ b/docker/runtime/Dockerfile.dev
@@ -29,7 +29,7 @@ RUN patchright install-deps firefox
 RUN python -m camoufox fetch
 RUN python -m cloakbrowser install
 
-COPY scripts/verify_browser_runtime.py ./scripts/verify_browser_runtime.py
+COPY . /app
 RUN python scripts/verify_browser_runtime.py
 
 ENV PYTHONPATH=/app

--- a/docker/runtime/Dockerfile.prod
+++ b/docker/runtime/Dockerfile.prod
@@ -26,7 +26,7 @@ RUN sed -i 's/^Components: main$/Components: main contrib/' \
         ttf-mscorefonts-installer \
     && fc-cache -f \
     && rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /opt/job-ftch-home /opt/playwright && chown -R appuser:appuser /opt/job-ftch-home /opt/playwright
+RUN mkdir -p /opt/job-ftch-home /opt/playwright && chown appuser:appuser /opt/job-ftch-home /opt/playwright
 
 # Dependency metadata only, with a placehnewer package so the wheel can build. The verify
 # script is copied after the installs on purpose: copying it here tied the ~1.1 GB install
@@ -42,12 +42,14 @@ RUN patchright install --with-deps chromium
 # `camoufox fetch` only downloads the binary, so without this the tier imports fine and
 # then dies at launch with "libgtk-3.so.0: cannot open shared object file".
 RUN patchright install-deps firefox
+RUN mkdir -p /opt/job-ftch-home/.cache/camoufox \
+    && chown appuser:appuser /opt/job-ftch-home/.cache/camoufox
 RUN python -m camoufox fetch
 RUN python -m cloakbrowser install
-RUN chown -R appuser:appuser /opt/job-ftch-home /opt/playwright
 
 COPY --chown=appuser:appuser . /app
-RUN mkdir -p /app/.runtime && chown -R appuser:appuser /app /app/.runtime
+RUN mkdir -p /app/.runtime /app/artifacts \
+    && chown appuser:appuser /app/.runtime /app/artifacts
 
 COPY scripts/verify_browser_runtime.py ./scripts/verify_browser_runtime.py
 

--- a/job_ftch/adapters/telegram_bot/Dockerfile.prod
+++ b/job_ftch/adapters/telegram_bot/Dockerfile.prod
@@ -3,22 +3,6 @@ FROM ${BASE_IMAGE}
 
 WORKDIR /app
 
-# The bot executes browser-backed sources itself, so do not rely on a stale
-# runtime base image to supply Patchright or Chromium.
-USER root
-COPY pyproject.toml README.md LICENSE uv.lock ./
-RUN /usr/local/bin/python -m pip install --no-cache-dir "uv==0.9.26" \
-    && uv sync --locked --no-dev --all-extras \
-    && patchright install --with-deps chromium \
-    && patchright install-deps firefox \
-    && HOME=/opt/job-ftch-home camoufox set official/stable \
-    && HOME=/opt/job-ftch-home camoufox fetch \
-    && HOME=/opt/job-ftch-home python -m cloakbrowser install \
-    && (getent group appuser >/dev/null || groupadd --system appuser) \
-    && (id -u appuser >/dev/null 2>&1 || useradd --system --gid appuser --home-dir /opt/job-ftch-home --shell /usr/sbin/nologin appuser) \
-    && mkdir -p /opt/job-ftch-home \
-    && chown -R appuser:appuser /opt/job-ftch-home /opt/playwright
-
 # Bake the current source over the runtime base so standalone production images
 # execute the exact adapter revision that was built.
 COPY --chown=appuser:appuser . /app

--- a/job_ftch/domain/source_outcomes.py
+++ b/job_ftch/domain/source_outcomes.py
@@ -15,5 +15,11 @@ SourceOutcome = Literal[
     "unconfirmed_empty",
     "no_open_vacancies",
     "board_gone",
+    "source_error",
+    "transport_error",
+    "upstream_error",
+    "parser_error",
+    "policy_not_scraped",
+    "rate_limited",
     "failed",
 ]

--- a/job_ftch/infrastructure/bypass/adaptive.py
+++ b/job_ftch/infrastructure/bypass/adaptive.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import os
 import re
@@ -850,12 +851,16 @@ class AdaptiveBypassManager:
         raw: Any = None
         exporter = getattr(page, "export_cookies", None)
         if callable(exporter):
-            raw = await exporter()
+            raw = exporter()
+            if inspect.isawaitable(raw):
+                raw = await raw
         else:
             context = getattr(page, "context", None)
             cookies = getattr(context, "cookies", None)
             if callable(cookies):
-                raw = await cookies()
+                raw = cookies()
+                if inspect.isawaitable(raw):
+                    raw = await raw
         if not isinstance(raw, list):
             return
         allowed: list[dict[str, Any]] = []

--- a/job_ftch/infrastructure/bypass/nodriver_bypass.py
+++ b/job_ftch/infrastructure/bypass/nodriver_bypass.py
@@ -31,6 +31,9 @@ except ImportError:
 
 _PROFILE_LOCKS: dict[str, asyncio.Lock] = {}
 _PROFILE_LOCKS_GUARD = asyncio.Lock()
+# ponytail: one process-wide launch lock; per-profile locks serialize normal
+# use, while Chromium startup itself is fragile under concurrent spawns.
+_NODRIVER_START_LOCK = asyncio.Lock()
 logger = structlog.get_logger(__name__)
 
 
@@ -476,6 +479,21 @@ class NodriverBypass:
         current_user_data_dir = user_data_dir
         current_owns_profile_dir = owns_profile_dir
         recovery_attempted = False
+        sandbox_fallback_attempted = False
+        current_config = config
+        failed_shared_profile: str | None = None
+
+        async def _quarantine_recovered_profile() -> None:
+            if failed_shared_profile is None:
+                return
+            profile_lock = await _profile_lock_for(failed_shared_profile)
+            async with profile_lock:
+                if _quarantine_profile_dir(failed_shared_profile):
+                    logger.warning(
+                        "nodriver_profile_quarantined_after_clean_profile_succeeded",
+                        profile_hash=Path(failed_shared_profile).name,
+                    )
+
         while True:
             profile_lock = (
                 await _profile_lock_for(current_user_data_dir) if current_user_data_dir else None
@@ -485,7 +503,7 @@ class NodriverBypass:
                     async with (
                         profile_lock,
                         self._open_page_unlocked(
-                            config,
+                            current_config,
                             browser_args=browser_args,
                             user_data_dir=current_user_data_dir,
                             owns_profile_dir=current_owns_profile_dir,
@@ -494,10 +512,11 @@ class NodriverBypass:
                         ) as page,
                     ):
                         yield page
+                    await _quarantine_recovered_profile()
                     return
 
                 async with self._open_page_unlocked(
-                    config,
+                    current_config,
                     browser_args=browser_args,
                     user_data_dir=current_user_data_dir,
                     owns_profile_dir=current_owns_profile_dir,
@@ -505,8 +524,18 @@ class NodriverBypass:
                     viewport=viewport if isinstance(viewport, dict) else None,
                 ) as page:
                     yield page
+                await _quarantine_recovered_profile()
                 return
             except Exception as exc:
+                if (
+                    not sandbox_fallback_attempted
+                    and "sandbox" not in config
+                    and _is_nodriver_connect_failure(exc)
+                ):
+                    sandbox_fallback_attempted = True
+                    current_config = {**config, "sandbox": False}
+                    logger.warning("nodriver_sandbox_fallback_after_connect_failure")
+                    continue
                 if (
                     recovery_attempted
                     or not current_user_data_dir
@@ -515,15 +544,13 @@ class NodriverBypass:
                 ):
                     raise
                 recovery_attempted = True
-                if _quarantine_profile_dir(current_user_data_dir):
-                    logger.warning(
-                        "nodriver_profile_quarantined_after_connect_failure",
-                        profile_hash=Path(current_user_data_dir).name,
-                    )
-                    continue
+                failed_shared_profile = current_user_data_dir
                 current_user_data_dir = tempfile.mkdtemp(prefix="nodriver_recovery_profile_")
                 current_owns_profile_dir = True
-                logger.warning("nodriver_profile_recovery_using_temp_profile")
+                logger.warning(
+                    "nodriver_profile_recovery_using_temp_profile",
+                    profile_hash=Path(str(user_data_dir)).name,
+                )
 
     @asynccontextmanager
     async def _open_page_unlocked(
@@ -539,16 +566,41 @@ class NodriverBypass:
         sandbox = bool(config.get("sandbox", True))
         if getattr(os, "geteuid", lambda: 1000)() == 0:
             sandbox = False
-        browser = await nodriver.start(
-            headless=bool(config.get("headless", True)),
-            user_data_dir=user_data_dir,
-            browser_executable_path=self._browser_executable_path,
-            browser_args=browser_args,
-            # Chromium refuses its sandbox when the worker runs as root (the
-            # production container does). Keep it enabled for ordinary users.
+
+        async def _start() -> Any:
+            async with _NODRIVER_START_LOCK:
+                return await nodriver.start(
+                    headless=bool(config.get("headless", True)),
+                    user_data_dir=user_data_dir,
+                    browser_executable_path=self._browser_executable_path,
+                    browser_args=browser_args,
+                    # Chromium refuses its sandbox when the worker runs as root.
+                    # Keep it enabled for ordinary users.
+                    sandbox=sandbox,
+                    lang=self._lang or str(config.get("locale", "en-US")),
+                )
+
+        started_at = time.monotonic()
+        logger.info(
+            "nodriver_starting",
+            uid=getattr(os, "geteuid", lambda: None)(),
+            executable_exists=bool(
+                self._browser_executable_path and Path(self._browser_executable_path).is_file()
+            ),
+            persistent_profile=bool(user_data_dir and not owns_profile_dir),
             sandbox=sandbox,
-            lang=self._lang or str(config.get("locale", "en-US")),
         )
+        try:
+            browser = await _start()
+        except Exception as exc:
+            if not _is_nodriver_connect_failure(exc):
+                raise
+            from job_ftch.infrastructure.sources.browser_utils import reap_stale_browser_drivers
+
+            reap_stale_browser_drivers()
+            await asyncio.sleep(0.1)
+            browser = await _start()
+        logger.info("nodriver_started", elapsed_seconds=round(time.monotonic() - started_at, 3))
         proxy_url = (
             config.get("_proxy_url") or os.environ.get("JOB_FTCH_HTTP_PROXY") if use_proxy else None
         )
@@ -575,9 +627,7 @@ class NodriverBypass:
                 )
             yield page
         finally:
-            stop_result = browser.stop()
-            if inspect.isawaitable(stop_result):
-                await stop_result
+            await _close_nodriver_browser(browser)
             if user_data_dir is not None and owns_profile_dir:
                 shutil.rmtree(user_data_dir, ignore_errors=True)
 
@@ -622,24 +672,45 @@ def _is_nodriver_connect_failure(exc: Exception) -> bool:
     return "failed to connect to browser" in message
 
 
-def _playwright_eval_expression(expression: str) -> str:
-    stripped = expression.strip()
-    if stripped.startswith("() =>") or stripped.startswith("async () =>"):
-        return f"({expression})()"
-    if stripped.startswith("function"):
-        return f"({expression})()"
-    return expression
+async def _close_nodriver_browser(browser: Any) -> None:
+    """Close nodriver's CDP transport and reap its subprocess before loop shutdown."""
+    from job_ftch.infrastructure.sources.browser_utils import _await_browser_cleanup
+
+    close = getattr(browser, "aclose", None)
+    process = getattr(browser, "_process", None)
+    if callable(close):
+        await _await_browser_cleanup(close(), label="nodriver.browser.aclose")
+        if process is not None and getattr(process, "returncode", None) is None:
+            with suppress(ProcessLookupError):
+                process.terminate()
+            wait = getattr(process, "wait", None)
+            if callable(wait) and not await _await_browser_cleanup(
+                wait(), label="nodriver.browser.wait"
+            ):
+                with suppress(ProcessLookupError):
+                    process.kill()
+                await _await_browser_cleanup(wait(), label="nodriver.browser.kill_wait")
+        return
+
+    stop = getattr(browser, "stop", None)
+    if callable(stop):
+        result = stop()
+        if inspect.isawaitable(result):
+            await _await_browser_cleanup(result, label="nodriver.browser.stop")
 
 
 def _quarantine_profile_dir(user_data_dir: str) -> bool:
+    """Move one proven-bad shared profile and retain only its newest snapshot."""
     path = Path(user_data_dir)
     if not path.exists():
         return True
     quarantine_root = path.parent / "_quarantine"
-    target = quarantine_root / f"{path.name}.{int(time.time())}.{os.getpid()}"
+    target = quarantine_root / f"{path.name}.{time.time_ns()}.{os.getpid()}"
     try:
         quarantine_root.mkdir(parents=True, exist_ok=True)
         shutil.move(str(path), str(target))
+        for stale in sorted(quarantine_root.glob(f"{path.name}.*"))[:-1]:
+            shutil.rmtree(stale, ignore_errors=True)
     except OSError as exc:
         logger.warning(
             "nodriver_profile_quarantine_failed",
@@ -648,6 +719,15 @@ def _quarantine_profile_dir(user_data_dir: str) -> bool:
         )
         return False
     return True
+
+
+def _playwright_eval_expression(expression: str) -> str:
+    stripped = expression.strip()
+    if stripped.startswith("() =>") or stripped.startswith("async () =>"):
+        return f"({expression})()"
+    if stripped.startswith("function"):
+        return f"({expression})()"
+    return expression
 
 
 def _materialize_runtime_value(raw: Any) -> Any:

--- a/job_ftch/infrastructure/sources/browser_utils.py
+++ b/job_ftch/infrastructure/sources/browser_utils.py
@@ -284,29 +284,37 @@ def _install_patchright_cancellation_fix() -> None:
         setattr(RouteHandler, _PATCHRIGHT_ROUTE_FIX_ATTR, True)
 
 
-async def _await_browser_cleanup(awaitable: Any, *, label: str) -> None:
+async def _await_browser_cleanup(
+    awaitable: Any,
+    *,
+    label: str,
+    timeout_seconds: float | None = None,
+) -> bool:
     task = asyncio.ensure_future(awaitable)
+    timeout = (
+        _BROWSER_CLEANUP_TIMEOUT_SECONDS if timeout_seconds is None else max(0.0, timeout_seconds)
+    )
     try:
-        await asyncio.wait_for(task, timeout=_BROWSER_CLEANUP_TIMEOUT_SECONDS)
+        await asyncio.wait_for(asyncio.shield(task), timeout=timeout)
+        return True
     except TimeoutError:
         task.cancel()
         with suppress(asyncio.CancelledError, Exception):
-            await task
+            await asyncio.wait_for(asyncio.shield(task), timeout=0.25)
         log.warning("browser.cleanup_timeout", step=label)
+        return False
     except asyncio.CancelledError:
-        task.cancel()
         with suppress(asyncio.CancelledError, Exception):
-            await task
+            await asyncio.wait_for(asyncio.shield(task), timeout=0.25)
+        if not task.done():
+            task.cancel()
+            with suppress(asyncio.CancelledError, Exception):
+                await task
         log.warning("browser.cleanup_cancelled", step=label)
+        raise
     except Exception as exc:
         log.debug("browser.cleanup_failed", step=label, error=type(exc).__name__)
-
-
-async def _call_browser_cleanup(target: Any, method_name: str, *, label: str) -> None:
-    method = getattr(target, method_name, None)
-    if not callable(method):
-        return
-    await _await_browser_cleanup(method(), label=label)
+        return False
 
 
 async def _unroute_page_before_close(page: Any) -> None:
@@ -314,7 +322,46 @@ async def _unroute_page_before_close(page: Any) -> None:
     unroute_all = getattr(page, "unroute_all", None)
     if not callable(unroute_all):
         return
-    await _await_browser_cleanup(unroute_all(behavior="ignoreErrors"), label="unroute_all")
+    await _await_browser_cleanup(unroute_all(behavior="wait"), label="unroute_all")
+
+
+async def _cleanup_browser_stack(page: Any, context: Any, browser: Any | None = None) -> None:
+    """Close one browser stack inside a single shared cleanup deadline."""
+    loop = asyncio.get_running_loop()
+    total_budget = _BROWSER_CLEANUP_TIMEOUT_SECONDS
+    deadline = loop.time() + total_budget
+    step_cap = max(0.001, min(0.5, total_budget / 5))
+
+    async def _step(awaitable: Any, *, label: str, cap: float | None = None) -> bool:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            if inspect.iscoroutine(awaitable):
+                awaitable.close()
+            return False
+        return await _await_browser_cleanup(
+            awaitable,
+            label=label,
+            timeout_seconds=min(remaining, cap) if cap is not None else remaining,
+        )
+
+    unroute_all = getattr(page, "unroute_all", None)
+    if callable(unroute_all):
+        drained = await _step(unroute_all(behavior="wait"), label="unroute_all", cap=step_cap)
+        if not drained:
+            await _step(
+                unroute_all(behavior="ignoreErrors"),
+                label="unroute_all.ignore_errors",
+                cap=step_cap,
+            )
+
+    for target, method_name, label in (
+        (page, "close", "page.close"),
+        (context, "close", "context.close"),
+        (browser, "close", "browser.close"),
+    ):
+        method = getattr(target, method_name, None)
+        if callable(method):
+            await _step(method(), label=label, cap=step_cap)
 
 
 def _proc_signature(proc: Any) -> str:
@@ -791,10 +838,7 @@ async def _open_playwright_page(
         # Windows when navigation was cancelled by a source deadline.  Close
         # the innermost resources first; every close is best-effort because a
         # target may already have been terminated by Patchright.
-        await _unroute_page_before_close(page)
-        await _call_browser_cleanup(page, "close", label="page.close")
-        await _call_browser_cleanup(context, "close", label="context.close")
-        await _call_browser_cleanup(browser, "close", label="browser.close")
+        await _cleanup_browser_stack(page, context, browser)
         reap_stale_browser_drivers()
 
 
@@ -914,9 +958,7 @@ async def _open_persistent_page(
             await page.goto(config["warmup_url"])
         yield page
     finally:
-        await _unroute_page_before_close(page)
-        await _call_browser_cleanup(page, "close", label="page.close")
-        await _call_browser_cleanup(context, "close", label="context.close")
+        await _cleanup_browser_stack(page, context)
         reap_stale_browser_drivers()
         import shutil
 

--- a/job_ftch/infrastructure/sources/career_site_source.py
+++ b/job_ftch/infrastructure/sources/career_site_source.py
@@ -98,6 +98,30 @@ class ZeroYieldReason(StrEnum):
     SOFT_403_WITH_CONTENT = "soft_403_with_content"
     STALE_URL = "stale_url"
     PARSER_GAP = "parser_gap"
+    MONITOR_ERROR = "monitor_error"
+    TRANSPORT_ERROR = "transport_error"
+    UPSTREAM_ERROR = "upstream_error"
+    PARSER_ERROR = "parser_error"
+    POLICY_NOT_SCRAPED = "policy_not_scraped"
+    RATE_LIMITED = "rate_limited"
+
+
+_TYPED_FAILURE_REASONS = frozenset(
+    {
+        ZeroYieldReason.BLOCKED_NO_BYPASS_LEFT,
+        ZeroYieldReason.WAF_CHALLENGE,
+        ZeroYieldReason.PROVIDER_TUNNEL_DENIED,
+        ZeroYieldReason.SOFT_403_WITH_CONTENT,
+        ZeroYieldReason.STALE_URL,
+        ZeroYieldReason.BOARD_GONE,
+        ZeroYieldReason.MONITOR_ERROR,
+        ZeroYieldReason.TRANSPORT_ERROR,
+        ZeroYieldReason.UPSTREAM_ERROR,
+        ZeroYieldReason.PARSER_ERROR,
+        ZeroYieldReason.POLICY_NOT_SCRAPED,
+        ZeroYieldReason.RATE_LIMITED,
+    }
+)
 
 
 @dataclass
@@ -237,25 +261,14 @@ def _has_substantial_html_content(body: bytes | None) -> bool:
     return len(visible) >= 200
 
 
-def _classified_zero_reason(
-    exc: BaseException | None,
-    *,
-    status_code: int | None = None,
-    response_body: bytes | None = None,
-) -> ZeroYieldReason:
-    return _classified_protection(
-        exc,
-        status_code=status_code,
-        response_body=response_body,
-    )[0]
-
-
-def _classified_protection(
+def _classified_failure(
     exc: BaseException | None,
     *,
     status_code: int | None = None,
     response_body: bytes | None = None,
 ) -> tuple[ZeroYieldReason, str | None]:
+    from job_ftch.infrastructure.bypass.failure_signal import FailureKind, classify_error
+
     error_text = str(exc or "").casefold()
     if "err_tunnel_connection_failed" in error_text or "tunnel connection failed" in error_text:
         return ZeroYieldReason.PROVIDER_TUNNEL_DENIED, None
@@ -263,9 +276,9 @@ def _classified_protection(
         return ZeroYieldReason.SOFT_403_WITH_CONTENT, None
     if status_code in {404, 410}:
         return ZeroYieldReason.STALE_URL, None
+    classified_kind = classify_error(exc) if exc is not None else FailureKind.UNKNOWN
     if response_body:
         from job_ftch.infrastructure.bypass.failure_signal import (
-            FailureKind,
             HeuristicFailureSignal,
         )
 
@@ -276,9 +289,37 @@ def _classified_protection(
         )
         if outcome.kind in {FailureKind.CAPTCHA, FailureKind.CHALLENGE}:
             return ZeroYieldReason.WAF_CHALLENGE, outcome.captcha_type
-    if status_code in {401, 403, 429, 498, 499}:
+        if classified_kind == FailureKind.UNKNOWN:
+            classified_kind = outcome.kind
+    if status_code == 429 or classified_kind == FailureKind.RATE_LIMIT:
+        return ZeroYieldReason.RATE_LIMITED, None
+    if status_code in {401, 403, 498, 499} or classified_kind in {
+        FailureKind.AUTH_REQUIRED,
+        FailureKind.BLOCKED,
+        FailureKind.BLOCKED_IP,
+        FailureKind.BLOCKED_FINGERPRINT,
+        FailureKind.BLOCKED_CHROMIUM_FINGERPRINT,
+        FailureKind.CAPTCHA,
+        FailureKind.CHALLENGE,
+        FailureKind.QRATOR_CHALLENGE,
+        FailureKind.SILENT_BLOCK,
+    }:
         return ZeroYieldReason.WAF_CHALLENGE, None
-    return ZeroYieldReason.BLOCKED_NO_BYPASS_LEFT, None
+    if (isinstance(status_code, int) and status_code >= 500) or classified_kind in {
+        FailureKind.SERVER_ERROR,
+        FailureKind.PAYMENT_REQUIRED,
+    }:
+        return ZeroYieldReason.UPSTREAM_ERROR, None
+    if classified_kind in {
+        FailureKind.TIMEOUT,
+        FailureKind.DNS_ERROR,
+        FailureKind.CONNECT_ERROR,
+        FailureKind.TLS_ERROR,
+    }:
+        return ZeroYieldReason.TRANSPORT_ERROR, None
+    if classified_kind == FailureKind.PARSER_ERROR:
+        return ZeroYieldReason.PARSER_ERROR, None
+    return ZeroYieldReason.MONITOR_ERROR, None
 
 
 def _looks_like_spa_shell(html: str | None) -> bool:
@@ -724,14 +765,13 @@ class CareerSiteSource(Source["RawItem"]):
                 failure_kind=failure_kind,
             )
             self.stats.monitor_failure_without_escalation += 1
-            if status_code in {401, 403, 429, 498, 499} or _is_protected_source_error(exc):
-                self.stats.zero_reason, captcha_type = _classified_protection(
-                    exc,
-                    status_code=status_code,
-                    response_body=response_body,
-                )
-                if captcha_type and captcha_type not in self.stats.detected_captcha_types:
-                    self.stats.detected_captcha_types.append(captcha_type)
+            self.stats.zero_reason, captcha_type = _classified_failure(
+                exc,
+                status_code=status_code,
+                response_body=response_body,
+            )
+            if captcha_type and captcha_type not in self.stats.detected_captcha_types:
+                self.stats.detected_captcha_types.append(captcha_type)
             return False
 
         from job_ftch.infrastructure.bypass.failure_signal import (
@@ -774,7 +814,7 @@ class CareerSiteSource(Source["RawItem"]):
         if escalatable:
             status = getattr(getattr(exc, "response", None), "status_code", None)
             body = getattr(getattr(exc, "response", None), "content", None)
-            self.stats.zero_reason, captcha_type = _classified_protection(
+            self.stats.zero_reason, captcha_type = _classified_failure(
                 exc,
                 status_code=status,
                 response_body=body,
@@ -925,6 +965,9 @@ class CareerSiteSource(Source["RawItem"]):
                         elif getattr(site_parser, "confirmed_empty_on_empty", False):
                             self.stats.zero_reason = ZeroYieldReason.CONFIRMED_EMPTY
                             self._parser_failure_is_terminal = True
+                        elif getattr(site_parser, "terminal_on_empty", False):
+                            self.stats.zero_reason = ZeroYieldReason.POLICY_NOT_SCRAPED
+                            self._parser_failure_is_terminal = True
                         return
                     else:
                         parsed = 0
@@ -961,9 +1004,7 @@ class CareerSiteSource(Source["RawItem"]):
                             # public listing data when unauthenticated.  A
                             # generic crawl after their dedicated parser adds
                             # noise and must not be mistaken for an empty site.
-                            self.stats.zero_reason = (
-                                self.stats.zero_reason or ZeroYieldReason.BLOCKED_NO_BYPASS_LEFT
-                            )
+                            self.stats.zero_reason = ZeroYieldReason.POLICY_NOT_SCRAPED
                             self._parser_failure_is_terminal = True
                             return
                         break  # Parsed but found 0 items, break out of bypass loop
@@ -989,6 +1030,19 @@ class CareerSiteSource(Source["RawItem"]):
                             self.stats.freshness_filtered = freshness_filtered_before
                             self.stats.freshness_undated_passed = freshness_undated_before
                         continue
+                    if getattr(site_parser, "terminal_on_error", False):
+                        reason, _captcha_type = _classified_failure(
+                            exc,
+                            status_code=response.status_code if response is not None else None,
+                            response_body=body,
+                        )
+                        self.stats.zero_reason = (
+                            ZeroYieldReason.PARSER_ERROR
+                            if reason == ZeroYieldReason.MONITOR_ERROR
+                            else reason
+                        )
+                        self._parser_failure_is_terminal = True
+                        raise
                     if self.spec.site_parser:
                         # Pinned parser failures must remain visible to the
                         # audit; generic fallback would produce false health.
@@ -1031,6 +1085,13 @@ class CareerSiteSource(Source["RawItem"]):
                         "deadline",
                         "challenge_required",
                     }:
+                        self.stats.zero_reason = (
+                            ZeroYieldReason.WAF_CHALLENGE
+                            if parser_kind in {"auth_wall", "challenge_required"}
+                            else ZeroYieldReason.TRANSPORT_ERROR
+                            if parser_kind == "deadline"
+                            else ZeroYieldReason.PARSER_ERROR
+                        )
                         self._parser_failure_is_terminal = True
                         logger.warning(
                             "site_parser_failed_terminal",
@@ -1182,29 +1243,38 @@ class CareerSiteSource(Source["RawItem"]):
                     if response is not None or _is_protected_source_error(exc):
                         body = getattr(response, "content", None) if response is not None else None
                         status_code = response.status_code if response is not None else None
-                        self.stats.zero_reason, captcha_type = _classified_protection(
+                        self.stats.zero_reason, captcha_type = _classified_failure(
                             exc,
                             status_code=status_code,
                             response_body=body,
                         )
-                        if captcha_type and captcha_type not in self.stats.detected_captcha_types:
-                            self.stats.detected_captcha_types.append(captcha_type)
-                        self.stats.challenge_events.append(
-                            {
-                                "surface": "monitor_detector",
-                                "type": captcha_type or "challenge",
-                                "confidence": 0.92 if captcha_type else 0.74,
-                                "status_code": status_code,
-                            }
-                        )
-                        set_challenge_type = getattr(
-                            self.bypass_strategy,
-                            "set_observed_challenge_type",
-                            None,
-                        )
-                        if captcha_type and callable(set_challenge_type):
-                            with contextlib.suppress(Exception):
-                                set_challenge_type(captcha_type)
+                        if self.stats.zero_reason in {
+                            ZeroYieldReason.BLOCKED_NO_BYPASS_LEFT,
+                            ZeroYieldReason.WAF_CHALLENGE,
+                            ZeroYieldReason.SOFT_403_WITH_CONTENT,
+                            ZeroYieldReason.RATE_LIMITED,
+                        }:
+                            if (
+                                captcha_type
+                                and captcha_type not in self.stats.detected_captcha_types
+                            ):
+                                self.stats.detected_captcha_types.append(captcha_type)
+                            self.stats.challenge_events.append(
+                                {
+                                    "surface": "monitor_detector",
+                                    "type": captcha_type or "challenge",
+                                    "confidence": 0.92 if captcha_type else 0.74,
+                                    "status_code": status_code,
+                                }
+                            )
+                            set_challenge_type = getattr(
+                                self.bypass_strategy,
+                                "set_observed_challenge_type",
+                                None,
+                            )
+                            if captcha_type and callable(set_challenge_type):
+                                with contextlib.suppress(Exception):
+                                    set_challenge_type(captcha_type)
                     monitors_to_try = ["dom", "api_sniffer"]
                     self.stats.recommended_monitors = list(monitors_to_try)
 
@@ -1394,10 +1464,10 @@ class CareerSiteSource(Source["RawItem"]):
                     body = response.content if response is not None else None
                     if await self._try_escalate_bypass(exc, response=response, response_body=body):
                         continue
-                    self.stats.zero_reason = (
-                        self.stats.zero_reason or ZeroYieldReason.BLOCKED_NO_BYPASS_LEFT
-                    )
                     if _is_protected_source_error(exc):
+                        self.stats.zero_reason = (
+                            self.stats.zero_reason or ZeroYieldReason.BLOCKED_NO_BYPASS_LEFT
+                        )
                         # All available bypass tiers have rejected this listing.
                         # Trying the remaining generic monitors only repeats the
                         # protected request and turns a clear 403/429 outcome
@@ -1409,6 +1479,7 @@ class CareerSiteSource(Source["RawItem"]):
                             error=str(exc),
                         )
                         return
+                    self.stats.zero_reason = self.stats.zero_reason or ZeroYieldReason.MONITOR_ERROR
                     logger.warning("monitor_run_failed", name=current_monitor_name, error=str(exc))
                     break  # Try next monitor in chain
 
@@ -1541,7 +1612,7 @@ class CareerSiteSource(Source["RawItem"]):
                     yield item
                 attempt_items_emitted = self.stats.rich_emitted + self.stats.scraped - items_before
                 if attempt_items_emitted == 0 and current_monitor_name != monitors_to_try[-1]:
-                    if self.stats.zero_reason != ZeroYieldReason.BLOCKED_NO_BYPASS_LEFT:
+                    if self.stats.zero_reason not in _TYPED_FAILURE_REASONS:
                         self.stats.zero_reason = ZeroYieldReason.ALL_SCRAPERS_FAILED
                     logger.info(
                         "monitor_yielded_no_valid_items_after_scraping_trying_next",
@@ -1591,7 +1662,7 @@ class CareerSiteSource(Source["RawItem"]):
                 # The final monitor found listing-like candidates but could
                 # not confirm a detail posting.  It is not evidence of an
                 # empty career site; preserve the extraction failure instead.
-                if self.stats.zero_reason != ZeroYieldReason.BLOCKED_NO_BYPASS_LEFT:
+                if self.stats.zero_reason not in _TYPED_FAILURE_REASONS:
                     self.stats.zero_reason = ZeroYieldReason.ALL_SCRAPERS_FAILED
                 # This is the final monitor and this attempt produced no
                 # usable item.  Continuing the inner retry loop re-runs the
@@ -1606,7 +1677,7 @@ class CareerSiteSource(Source["RawItem"]):
             )
         elif self.stats.zero_reason not in {
             ZeroYieldReason.ALL_SCRAPERS_FAILED,
-            ZeroYieldReason.BLOCKED_NO_BYPASS_LEFT,
+            *_TYPED_FAILURE_REASONS,
         }:
             self.stats.zero_reason = ZeroYieldReason.ALL_MONITORS_EXHAUSTED
         logger.info("career_site_fetch_exhausted_all_monitors", **self.stats.to_log_dict())
@@ -2488,7 +2559,8 @@ class CareerSiteSource(Source["RawItem"]):
         # request suppression only; it must not change a protected source into
         # ``all_scrapers_failed`` merely because it exposed fewer detail URLs
         # than the circuit-breaker threshold.
-        self.stats.zero_reason = self.stats.zero_reason or ZeroYieldReason.BLOCKED_NO_BYPASS_LEFT
+        if self.stats.zero_reason in {None, ZeroYieldReason.ALL_SCRAPERS_FAILED}:
+            self.stats.zero_reason = ZeroYieldReason.BLOCKED_NO_BYPASS_LEFT
         if (
             self.stats.detail_protection_failures
             < get_settings().career_site_protection_failure_limit

--- a/job_ftch/infrastructure/sources/composite.py
+++ b/job_ftch/infrastructure/sources/composite.py
@@ -61,6 +61,8 @@ class SourceFetchResult:
     generic_scraper_used: bool = False
     parser_urls_discovered: int = 0
     detail_cards_extracted: int = 0
+    detail_attempted: int = 0
+    detail_protection_failures: int = 0
 
 
 _TECHNICAL_ZERO_REASONS = {
@@ -72,6 +74,12 @@ _TECHNICAL_ZERO_REASONS = {
     "soft_403_with_content",
     "stale_url",
     "parser_gap",
+    "monitor_error",
+    "transport_error",
+    "upstream_error",
+    "parser_error",
+    "policy_not_scraped",
+    "rate_limited",
 }
 
 _OUTCOME_BY_ZERO_REASON = {
@@ -81,13 +89,26 @@ _OUTCOME_BY_ZERO_REASON = {
     "soft_403_with_content": "soft_403_with_content",
     "stale_url": "stale_url",
     "parser_gap": "parser_gap",
-    "all_scrapers_failed": "detail_extraction_failed",
-    "all_monitors_exhausted": "listing_discovery_failed",
     "monitor_empty": "unconfirmed_empty",
     "confirmed_empty": "no_open_vacancies",
     "board_gone": "board_gone",
+    "monitor_error": "source_error",
+    "transport_error": "transport_error",
+    "upstream_error": "upstream_error",
+    "parser_error": "parser_error",
+    "policy_not_scraped": "policy_not_scraped",
     "rate_limited": "rate_limited",
 }
+
+
+def _zero_yield_outcome(result: SourceFetchResult) -> SourceOutcome | None:
+    if result.zero_reason in {"all_scrapers_failed", "all_monitors_exhausted"}:
+        return (
+            "detail_extraction_failed"
+            if result.detail_attempted > 0 or result.parser_urls_discovered > 0
+            else "listing_discovery_failed"
+        )
+    return cast("SourceOutcome | None", _OUTCOME_BY_ZERO_REASON.get(result.zero_reason or ""))
 
 
 def _capture_source_stats(source: object, result: SourceFetchResult) -> None:
@@ -116,6 +137,8 @@ def _capture_source_stats(source: object, result: SourceFetchResult) -> None:
             "freshness_filtered",
             "freshness_undated_passed",
             "parser_duplicates_suppressed",
+            "detail_attempted",
+            "detail_protection_failures",
         ):
             setattr(result, name, int(getattr(stats, name, 0) or 0))
         result.requested_parser = getattr(stats, "requested_parser", None)
@@ -136,9 +159,7 @@ def _capture_source_stats(source: object, result: SourceFetchResult) -> None:
             result.terminal_outcome = "parsed_ok"
             result.completion_state = "completed_limited" if result.limited else "completed"
     elif result.zero_reason:
-        result.terminal_outcome = cast(
-            "SourceOutcome | None", _OUTCOME_BY_ZERO_REASON.get(result.zero_reason)
-        )
+        result.terminal_outcome = _zero_yield_outcome(result)
         # Keep the specific diagnostic outcome (for example failed detail
         # extraction) but never treat a hard-deadline run as a complete source
         # snapshot merely because it reached a zero-yield branch while timing

--- a/job_ftch/infrastructure/sources/monitors/dom.py
+++ b/job_ftch/infrastructure/sources/monitors/dom.py
@@ -32,6 +32,17 @@ def _is_probable_job_link(url: str) -> bool:
     return is_probable_job_url(url)
 
 
+def _http_url_values(raw: object) -> list[str]:
+    """Keep browser-evaluated values at the untrusted JS/Python boundary."""
+    if not isinstance(raw, list):
+        return []
+    return [
+        value.strip()
+        for value in raw
+        if isinstance(value, str) and value.strip().startswith("http")
+    ]
+
+
 MAX_URLS = 10_000
 _MAX_HTML_FOR_BOARD_CHECK = 500_000
 # One-level expansion is a recovery path, not a site crawl.  It is bounded so
@@ -353,12 +364,8 @@ async def visible_job_links_on_page(
     except Exception as exc:
         log.info("dom.visible_hrefs_failed", error=type(exc).__name__)
         return []
-    if not isinstance(raw, list):
-        return []
     filtered: set[str] = set()
-    for item in raw:
-        if not isinstance(item, str) or not item.startswith("http"):
-            continue
+    for item in _http_url_values(raw):
         if matcher:
             if matcher.search(item):
                 filtered.add(item)
@@ -440,7 +447,7 @@ async def _extract_links_rendered(
     raise_if_browser_challenge(html, url=board_url)
     check_ats_redirect(html, board_url)
 
-    urls: list[str] = await page.evaluate(_RENDERED_HREF_JS)
+    urls = _http_url_values(await page.evaluate(_RENDERED_HREF_JS))
 
     filtered: set[str] = set()
     for url in urls:

--- a/job_ftch/infrastructure/sources/site_parsers/justjoin.py
+++ b/job_ftch/infrastructure/sources/site_parsers/justjoin.py
@@ -21,6 +21,7 @@ _DOMAIN_PATTERN = r"justjoin\.it"
 class JustjoinItParser:
     domain_pattern = _DOMAIN_PATTERN
     has_custom_parse = True
+    terminal_on_error = True
 
     def runtime_defaults(self, url: str) -> SiteRuntimeDefaults:
         del url

--- a/job_ftch/infrastructure/sources/url_scoring.py
+++ b/job_ftch/infrastructure/sources/url_scoring.py
@@ -412,7 +412,10 @@ def looks_like_listing_url(url: str, *, board_url: str | None = None) -> bool:
 
 
 def rank_job_urls(urls: list[str] | set[str], *, board_url: str | None = None) -> list[str]:
-    scored = [(url, score_job_url(url, board_url=board_url)) for url in set(urls)]
+    scored = [
+        (url, score_job_url(url, board_url=board_url))
+        for url in {value for value in urls if isinstance(value, str)}
+    ]
     positives = [(url, score) for url, score in scored if score > 0]
     chosen = positives or scored
     chosen.sort(key=lambda item: (-item[1], item[0]))

--- a/scripts/run_ingest_batch.py
+++ b/scripts/run_ingest_batch.py
@@ -10,6 +10,7 @@ import contextlib
 import dataclasses
 import io
 import json
+import os
 import sys
 import threading
 import time
@@ -56,6 +57,20 @@ class _TimedProbeSource:
                 yield item
         finally:
             self.finished_at = time.monotonic()
+
+
+class _LiveProbe:
+    __slots__ = ("source", "source_result", "items")
+
+    def __init__(
+        self,
+        source: _TimedProbeSource,
+        source_result: SourceFetchResult,
+        items: list[dict[str, Any]],
+    ) -> None:
+        self.source = source
+        self.source_result = source_result
+        self.items = items
 
 
 def _parser_name(spec: CareerSiteSpec) -> str | None:
@@ -112,8 +127,6 @@ def _failure_bucket(
         and has_challenge_evidence
     ):
         return "waf_challenge"
-    if parser_name == "ProtectedBrowserDefaultsParser" and zero_reason == "blocked_no_bypass_left":
-        return "waf_challenge"
     if zero_reason == "parser_gap":
         return "parser_gap"
     if zero_reason == "provider_tunnel_denied":
@@ -123,10 +136,6 @@ def _failure_bucket(
     if source_result.terminal_outcome:
         return source_result.terminal_outcome
     if stats.get("zero_reason") == "blocked_no_bypass_left":
-        return "blocked_or_protected"
-    # LinkedIn is deliberately not scraped: an exhausted registered parser is
-    # an access-policy outcome, not evidence that a listing was absent.
-    if parser_name == "LinkedinParser":
         return "blocked_or_protected"
     if "429" in error:
         return "rate_limited"
@@ -167,7 +176,11 @@ def _probe_result(
 ) -> dict[str, Any]:
     raw_stats = getattr(source, "stats", {}) or {}
     stats = (
-        dataclasses.asdict(raw_stats) if dataclasses.is_dataclass(raw_stats) else dict(raw_stats)
+        dataclasses.asdict(raw_stats)
+        if dataclasses.is_dataclass(raw_stats)
+        else dict(raw_stats)
+        if isinstance(raw_stats, dict)
+        else vars(raw_stats)
     )
     bypass_obj = getattr(source, "bypass_strategy", None)
     final_tier = getattr(bypass_obj, "current_name", None)
@@ -274,6 +287,15 @@ def _probe_result(
                 "detected_captcha_types",
                 "challenge_events",
                 "monitor_failure_without_escalation",
+                "detail_attempted",
+                "detail_protection_failures",
+                "protection_circuit_open",
+                "requested_parser",
+                "actual_parser",
+                "parser_urls_discovered",
+                "detail_cards_extracted",
+                "monitor_attempts",
+                "successful_scraper",
             )
         },
         "selection": {"site_class": "not_probed", "recommended_monitors": []},
@@ -286,6 +308,7 @@ async def _probe_one(
     source_name: str,
     max_items: int,
     timeout_seconds: float,
+    live_probes: dict[str, _LiveProbe] | None = None,
 ) -> dict[str, Any]:
     """Probe one URL with an isolated source budget.
 
@@ -306,6 +329,8 @@ async def _probe_one(
         source_name=spec.source_name,
     )
     items: list[dict[str, Any]] = []
+    if live_probes is not None:
+        live_probes[url] = _LiveProbe(source, source_result, items)
     exc: BaseException | None = None
     started = time.monotonic()
 
@@ -353,7 +378,34 @@ async def _probe_one(
     )
 
 
-def _timeout_result(url: str, *, elapsed_seconds: float) -> dict[str, Any]:
+def _timeout_result(
+    url: str,
+    *,
+    elapsed_seconds: float,
+    live_probe: _LiveProbe | None = None,
+) -> dict[str, Any]:
+    if live_probe is not None:
+        source_result = dataclasses.replace(live_probe.source_result)
+        source_result.evicted = True
+        source_result.eviction_kind = "task_watchdog"
+        source_result.deadline_exceeded = True
+        source_result.hard_deadline_hit = True
+        source_result.partial = bool(live_probe.items)
+        source_result.failed = True
+        source_result.error = (
+            source_result.error or "TimeoutError: source task exceeded watchdog deadline"
+        )
+        _capture_source_stats(live_probe.source, source_result)
+        result = _probe_result(
+            url=url,
+            source=live_probe.source,
+            source_result=source_result,
+            items=list(live_probe.items),
+            elapsed=round(elapsed_seconds, 2),
+            overflow_workers_started=0,
+        )
+        result["eviction_kind"] = "task_watchdog"
+        return result
     return {
         "url": url,
         "parse_status": "parsed_failed",
@@ -391,8 +443,13 @@ def _timeout_result(url: str, *, elapsed_seconds: float) -> dict[str, Any]:
     }
 
 
-def _global_timeout_result(url: str, *, elapsed_seconds: float) -> dict[str, Any]:
-    result = _timeout_result(url, elapsed_seconds=elapsed_seconds)
+def _global_timeout_result(
+    url: str,
+    *,
+    elapsed_seconds: float,
+    live_probe: _LiveProbe | None = None,
+) -> dict[str, Any]:
+    result = _timeout_result(url, elapsed_seconds=elapsed_seconds, live_probe=live_probe)
     result.update(
         {
             "failure_bucket": "global_run_timeout",
@@ -615,6 +672,7 @@ async def main() -> int:
 
     task_started_at: dict[asyncio.Task[dict[str, Any]], float] = {}
     abandoned_tasks: set[asyncio.Task[dict[str, Any]]] = set()
+    live_probes: dict[str, _LiveProbe] = {}
 
     async def _bounded(url: str, index: int) -> dict[str, Any]:
         task = asyncio.current_task()
@@ -625,6 +683,7 @@ async def main() -> int:
             source_name=f"ingest_probe_{index}",
             max_items=args.max_items,
             timeout_seconds=args.timeout,
+            live_probes=live_probes,
         )
 
     url_index = {url: index for index, url in enumerate(urls)}
@@ -652,22 +711,22 @@ async def main() -> int:
         completed_count += 1
         stall_state["ts"] = time.monotonic()  # progress signal for the watchdog
         results_by_url[str(result["url"])] = result
+        live_probes.pop(str(result["url"]), None)
         _save_results()
         all_results = [results_by_url[url] for url in urls if url in results_by_url]
         ok_so_far = sum(1 for r in all_results if r["parse_status"] == "parsed_ok")
         print(f"  -> {completed_count}/{len(pending_urls)} new; {ok_so_far}/{len(all_results)} ok")
 
     def _abandon_overdue_task(task: asyncio.Task[dict[str, Any]]) -> dict[str, Any]:
-        from job_ftch.infrastructure.sources.browser_utils import terminate_browser_descendants
-
         url = url_by_task.pop(task)
         task.cancel()
         abandoned_tasks.add(task)
-        with contextlib.suppress(Exception):
-            terminate_browser_descendants(grace=1.0)
+        # Sibling sources are still running in this process.  Their browser
+        # descendants must not be killed just because this one timed out.
         return _timeout_result(
             url,
             elapsed_seconds=time.monotonic() - task_started_at.get(task, time.monotonic()),
+            live_probe=live_probes.get(url),
         )
 
     # Stall watchdog: if the event loop wedges on a hung/uncancellable browser
@@ -692,7 +751,17 @@ async def main() -> int:
                 )
                 with contextlib.suppress(Exception):
                     terminate_browser_descendants(grace=3.0)
-                stall_state["ts"] = time.monotonic()
+                progress_before_cleanup = stall_state["ts"]
+                if stall_stop.wait(max(0.1, args.hard_cancel_grace)):
+                    return
+                if stall_state["ts"] == progress_before_cleanup:
+                    print(
+                        "  !! event loop did not recover after browser teardown; "
+                        "forcing exit with incremental results preserved",
+                        flush=True,
+                    )
+                    sys.stderr.flush()
+                    os._exit(2)
 
     watchdog_thread = threading.Thread(
         target=_stall_watchdog, name="ingest-stall-watchdog", daemon=True
@@ -717,6 +786,7 @@ async def main() -> int:
                         url,
                         elapsed_seconds=time.monotonic()
                         - task_started_at.get(task, batch_started_at),
+                        live_probe=live_probes.get(url),
                     )
                 )
                 url_by_task.pop(task, None)
@@ -801,8 +871,6 @@ async def main() -> int:
 
 
 if __name__ == "__main__":
-    import os
-
     from job_ftch.infrastructure.sources.browser_utils import terminate_browser_descendants
 
     _exit_code = 0

--- a/scripts/verify_browser_runtime.py
+++ b/scripts/verify_browser_runtime.py
@@ -28,7 +28,7 @@ def _require_camoufox_can_launch() -> None:
     from camoufox.async_api import AsyncCamoufox
 
     async def _launch() -> None:
-        async with AsyncCamoufox(headless=True) as browser:
+        async with AsyncCamoufox(headless=True) as browser:  # type: ignore[no-untyped-call]
             page = await browser.new_page()
             await page.close()
 
@@ -53,6 +53,45 @@ def _require_patchright_can_launch() -> None:
         asyncio.run(_launch())
     except Exception as exc:  # noqa: BLE001 - expose the missing binary/library
         _fail(f"patchright Chromium failed to launch: {exc}")
+
+
+def _require_nodriver_can_launch(chromium_binary: Path) -> None:
+    """Exercise sequential and concurrent nodriver/CDP startup as appuser."""
+    import asyncio
+    import shutil
+    import tempfile
+
+    from job_ftch.infrastructure.bypass.nodriver_bypass import NodriverBypass
+
+    async def _launch(profile: str) -> None:
+        bypass = NodriverBypass(browser_executable_path=str(chromium_binary))
+        async with bypass.open_page(
+            {
+                "headless": True,
+                "persistent_context": True,
+                "_profile_dir": profile,
+                "sandbox": False,
+            }
+        ):
+            pass
+
+    async def _exercise() -> None:
+        root = tempfile.mkdtemp(prefix="nodriver_runtime_smoke_")
+        try:
+            sequential = str(Path(root) / "sequential")
+            await _launch(sequential)
+            await _launch(sequential)
+            await asyncio.gather(
+                _launch(str(Path(root) / "concurrent_a")),
+                _launch(str(Path(root) / "concurrent_b")),
+            )
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    try:
+        asyncio.run(_exercise())
+    except Exception as exc:  # noqa: BLE001 - expose the browser/CDP failure
+        _fail(f"nodriver Chromium failed to launch: {exc}")
 
 
 def main() -> None:
@@ -88,6 +127,7 @@ def main() -> None:
         _fail(f"cloakbrowser ensure_binary() returned a missing path: {cloak_binary}")
 
     _require_patchright_can_launch()
+    _require_nodriver_can_launch(chromium_binaries[0])
     _require_camoufox_can_launch()
 
     print("browser runtime ok")

--- a/tests/infrastructure/bypass/test_managed_bypass.py
+++ b/tests/infrastructure/bypass/test_managed_bypass.py
@@ -131,20 +131,51 @@ async def test_nodriver_recovers_corrupt_shared_profile(monkeypatch, tmp_path):
     class _FakeNodriver:
         async def start(self, **kwargs):
             starts.append(kwargs["user_data_dir"])
-            if len(starts) == 1:
+            if len(starts) <= 2:
                 raise Exception("Failed to connect to browser")
             return _FakeBrowser()
 
     monkeypatch.setattr(nodriver_bypass, "nodriver", _FakeNodriver())
 
     async with nodriver_bypass.NodriverBypass().open_page(
-        {"persistent_context": True, "_profile_dir": str(profile)}
+        {"persistent_context": True, "_profile_dir": str(profile), "sandbox": False}
     ):
         pass
 
-    assert starts == [str(profile.resolve()), str(profile.resolve())]
-    assert not (profile / "stale-lock").exists()
-    assert any((tmp_path / "_quarantine").glob("profile.*"))
+    assert starts[0] == str(profile.resolve())
+    assert starts[1] == starts[0]
+    assert len(starts) == 3
+    assert starts[2] != starts[0]
+    assert starts[2].startswith("nodriver_recovery_profile_") or starts[2].split("\\")[
+        -1
+    ].startswith("nodriver_recovery_profile_")
+    quarantined = list((tmp_path / "_quarantine").glob("profile.*"))
+    assert len(quarantined) == 1
+    assert (quarantined[0] / "stale-lock").exists()
+
+
+@pytest.mark.asyncio
+async def test_nodriver_keeps_shared_profile_when_clean_recovery_also_fails(monkeypatch, tmp_path):
+    import job_ftch.infrastructure.bypass.nodriver_bypass as nodriver_bypass
+
+    profile = tmp_path / "profile"
+    profile.mkdir()
+
+    class _FakeNodriver:
+        async def start(self, **kwargs):
+            del kwargs
+            raise Exception("Failed to connect to browser")
+
+    monkeypatch.setattr(nodriver_bypass, "nodriver", _FakeNodriver())
+
+    with pytest.raises(Exception, match="Failed to connect"):
+        async with nodriver_bypass.NodriverBypass().open_page(
+            {"persistent_context": True, "_profile_dir": str(profile), "sandbox": False}
+        ):
+            pass
+
+    assert profile.exists()
+    assert not (tmp_path / "_quarantine").exists()
 
 
 @pytest.mark.asyncio

--- a/tests/infrastructure/bypass/test_managed_bypass.py
+++ b/tests/infrastructure/bypass/test_managed_bypass.py
@@ -1,4 +1,5 @@
 import asyncio
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import httpx
@@ -146,9 +147,7 @@ async def test_nodriver_recovers_corrupt_shared_profile(monkeypatch, tmp_path):
     assert starts[1] == starts[0]
     assert len(starts) == 3
     assert starts[2] != starts[0]
-    assert starts[2].startswith("nodriver_recovery_profile_") or starts[2].split("\\")[
-        -1
-    ].startswith("nodriver_recovery_profile_")
+    assert Path(starts[2]).name.startswith("nodriver_recovery_profile_")
     quarantined = list((tmp_path / "_quarantine").glob("profile.*"))
     assert len(quarantined) == 1
     assert (quarantined[0] / "stale-lock").exists()

--- a/tests/infrastructure/bypass/test_session_fingerprint_consistency.py
+++ b/tests/infrastructure/bypass/test_session_fingerprint_consistency.py
@@ -235,6 +235,18 @@ async def test_clearance_cookie_continues_from_listing_to_details() -> None:
 
 
 @pytest.mark.asyncio
+async def test_sync_cookie_exporter_is_supported() -> None:
+    manager = AdaptiveBypassManager()
+    page = SimpleNamespace(export_cookies=lambda: [{"name": "cf_clearance", "value": "value"}])
+
+    await manager.capture_session_state(page)
+
+    assert manager.prepare_browser_config({"url": "https://example.test"})["cookies"] == [
+        {"name": "cf_clearance", "value": "value"}
+    ]
+
+
+@pytest.mark.asyncio
 async def test_listing_pagination_and_details_share_identity_and_profile() -> None:
     manager = AdaptiveBypassManager()
     context = SimpleNamespace(

--- a/tests/infrastructure/sources/test_ingest_outcome_contract.py
+++ b/tests/infrastructure/sources/test_ingest_outcome_contract.py
@@ -42,6 +42,40 @@ def test_primary_outcome_and_deadline_flags_are_independent() -> None:
     assert not result.hard_deadline_hit
 
 
+def test_discovered_urls_make_zero_yield_an_extraction_failure() -> None:
+    source = SimpleNamespace(
+        stats=SimpleNamespace(
+            zero_reason=SimpleNamespace(value="all_monitors_exhausted"),
+            parser_urls_discovered=42,
+            detail_attempted=0,
+            source_partial=False,
+            truncated=False,
+            monitor_truncated=0,
+        )
+    )
+    result = SourceFetchResult("career_site:x", "career_site", "x")
+
+    _capture_source_stats(source, result)
+
+    assert result.terminal_outcome == "detail_extraction_failed"
+
+
+def test_transport_failure_survives_composite_contract() -> None:
+    source = SimpleNamespace(
+        stats=SimpleNamespace(
+            zero_reason=SimpleNamespace(value="transport_error"),
+            source_partial=False,
+            truncated=False,
+            monitor_truncated=0,
+        )
+    )
+    result = SourceFetchResult("career_site:x", "career_site", "x")
+
+    _capture_source_stats(source, result)
+
+    assert result.terminal_outcome == "transport_error"
+
+
 def test_bypass_config_accepts_typed_nested_json_values() -> None:
     spec = CareerSiteSpec(
         url="https://example.test/jobs",

--- a/tests/scripts/test_run_ingest_batch.py
+++ b/tests/scripts/test_run_ingest_batch.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import pytest
@@ -207,6 +208,37 @@ def test_timeout_result_is_a_watchdog_deadline_failure() -> None:
     assert result["eviction_kind"] == "task_watchdog"
     assert result["deadline_exceeded"] is True
     assert result["elapsed_seconds"] == 12.35
+
+
+def test_timeout_result_preserves_live_source_evidence() -> None:
+    module = _load_script_module()
+    source_result = SourceFetchResult("career_site:slow", "career_site", "slow")
+    source = SimpleNamespace(
+        spec=CareerSiteSpec(url="https://slow.example.test/jobs", source_name="slow"),
+        stats=SimpleNamespace(
+            zero_reason=SimpleNamespace(value="all_scrapers_failed"),
+            parser_urls_discovered=12,
+            detail_attempted=3,
+            detail_protection_failures=1,
+            monitored=12,
+            source_partial=False,
+            truncated=False,
+            monitor_truncated=0,
+        ),
+        bypass_strategy=None,
+    )
+    live_probe = module._LiveProbe(source, source_result, [])
+
+    result = module._timeout_result(
+        "https://slow.example.test/jobs",
+        elapsed_seconds=12.345,
+        live_probe=live_probe,
+    )
+
+    assert result["deadline_exceeded"] is True
+    assert result["terminal_outcome"] == "detail_extraction_failed"
+    assert result["stats"]["detail_attempted"] == 3
+    assert result["stats"]["parser_urls_discovered"] == 12
 
 
 def test_probe_marks_items_from_partial_source_as_not_completed() -> None:

--- a/tests/test_browser_utils.py
+++ b/tests/test_browser_utils.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from job_ftch.infrastructure.sources.browser_utils import (
+    _cleanup_browser_stack,
     _launch_browser_with_recovery,
     _load_async_playwright,
     _patchright_inner_send_cancellation_safe,
@@ -84,7 +85,7 @@ async def test_patchright_route_callback_does_not_complete_cancelled_future() ->
 
 
 @pytest.mark.asyncio
-async def test_unroute_drain_suppresses_cancellation_to_finish_cleanup() -> None:
+async def test_unroute_drain_propagates_cancellation_after_cleanup_attempt() -> None:
     started = asyncio.Event()
     release = asyncio.Event()
     behaviors: list[str] = []
@@ -98,12 +99,10 @@ async def test_unroute_drain_suppresses_cancellation_to_finish_cleanup() -> None
     task = asyncio.create_task(_unroute_page_before_close(Page()))
     await started.wait()
     task.cancel()
-    await asyncio.sleep(0)
-    assert not task.done()
-
     release.set()
-    await task
-    assert behaviors == ["ignoreErrors"]
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert behaviors == ["wait"]
 
 
 @pytest.mark.asyncio
@@ -114,10 +113,34 @@ async def test_unroute_drain_is_bounded(monkeypatch: pytest.MonkeyPatch) -> None
 
     class Page:
         async def unroute_all(self, *, behavior: str) -> None:
-            assert behavior == "ignoreErrors"
+            assert behavior == "wait"
             await asyncio.Event().wait()
 
     await _unroute_page_before_close(Page())
+
+
+@pytest.mark.asyncio
+async def test_browser_stack_falls_back_and_closes_within_one_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from job_ftch.infrastructure.sources import browser_utils
+
+    monkeypatch.setattr(browser_utils, "_BROWSER_CLEANUP_TIMEOUT_SECONDS", 0.05)
+    calls: list[str] = []
+
+    class Target:
+        async def close(self) -> None:
+            calls.append("close")
+
+    class Page(Target):
+        async def unroute_all(self, *, behavior: str) -> None:
+            calls.append(behavior)
+            if behavior == "wait":
+                await asyncio.Event().wait()
+
+    await _cleanup_browser_stack(Page(), Target())
+
+    assert calls == ["wait", "ignoreErrors", "close", "close"]
 
 
 def test_select_stale_driver_pids_selects_old_childless_browsers() -> None:
@@ -303,7 +326,7 @@ async def test_open_page_applies_bypass_only_to_launch_kwargs(
     assert "proxy" not in context_kwargs
     assert "args" not in context_kwargs
     assert bypass.page_calls == 1
-    assert page.unroute_behaviors == ["ignoreErrors"]
+    assert page.unroute_behaviors == ["wait"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_career_site_generic.py
+++ b/tests/test_career_site_generic.py
@@ -13,6 +13,8 @@ from job_ftch.infrastructure.sources.career_site import client_for_config
 from job_ftch.infrastructure.sources.career_site_source import (
     CareerSiteSource,
     FetchStats,
+    ZeroYieldReason,
+    _classified_failure,
     _is_valid_detail_candidate,
 )
 from job_ftch.infrastructure.sources.embedded_state_utils import (
@@ -60,6 +62,23 @@ class FakeHttpClient:
     async def get(self, url: str, *, follow_redirects: bool = True):  # type: ignore[no-untyped-def]
         del follow_redirects
         return self._responses[url]
+
+
+@pytest.mark.parametrize(
+    ("error", "status_code", "expected"),
+    [
+        (TimeoutError("request timeout"), None, ZeroYieldReason.TRANSPORT_ERROR),
+        (RuntimeError("server error"), 500, ZeroYieldReason.UPSTREAM_ERROR),
+        (TypeError("unhashable type: list"), None, ZeroYieldReason.MONITOR_ERROR),
+    ],
+)
+def test_source_failures_are_not_relabelled_as_protected(
+    error: Exception, status_code: int | None, expected: ZeroYieldReason
+) -> None:
+    reason, captcha_type = _classified_failure(error, status_code=status_code)
+
+    assert reason == expected
+    assert captcha_type is None
 
 
 class _FakeManagedClient:

--- a/tests/test_composite_source.py
+++ b/tests/test_composite_source.py
@@ -201,7 +201,7 @@ def test_deadline_preserves_specific_zero_outcome_but_marks_partial() -> None:
 
     _capture_source_stats(source, result)
 
-    assert result.terminal_outcome == "detail_extraction_failed"
+    assert result.terminal_outcome == "listing_discovery_failed"
     assert result.completion_state == "partial"
 
 

--- a/tests/test_fetch_universal_career_source.py
+++ b/tests/test_fetch_universal_career_source.py
@@ -147,6 +147,29 @@ class _EmptySiteParser:
             yield
 
 
+class _PolicyLimitedDiscoveryParser:
+    has_custom_parse = True
+    supports_discover = True
+    terminal_on_empty = True
+    parser_name = "policy_limited"
+
+    async def discover(self, spec: CareerSiteSpec, client: object) -> list[str]:
+        del spec, client
+        return []
+
+
+class _TerminalErrorParser:
+    has_custom_parse = True
+    supports_discover = False
+    terminal_on_error = True
+    parser_name = "terminal_error"
+
+    async def parse(self, spec: CareerSiteSpec, client: object):  # type: ignore[no-untyped-def]
+        del spec, client
+        raise TypeError("malformed API payload")
+        yield  # pragma: no cover
+
+
 def test_should_enable_render_on_monitor_retry_for_browser_tiers() -> None:
     browser = SimpleNamespace(requires_browser=True)
     http_only = SimpleNamespace(requires_browser=False)
@@ -256,6 +279,52 @@ async def test_pinned_special_parser_empty_is_terminal(monkeypatch: MonkeyPatch)
     assert source.stats.requested_parser == "empty_special"
     assert source.stats.actual_parser == "empty_special"
     assert source.stats.monitor_attempts == []
+
+
+@pytest.mark.asyncio
+async def test_discovery_parser_terminal_empty_is_policy_outcome(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    from job_ftch.infrastructure.sources.career_site_source import ZeroYieldReason
+
+    source = CareerSiteSource(
+        spec=CareerSiteSpec(url="https://example.com/jobs", source_name="example"),
+        http_client=object(),
+        auth=MagicMock(),
+    )
+    source.bypass_strategy = _NoopBypass()
+    monkeypatch.setattr(
+        "job_ftch.application.registry.resolve_site_parser_for_spec",
+        lambda _: _PolicyLimitedDiscoveryParser(),
+    )
+
+    assert [item async for item in source._try_site_parser(object())] == []
+    assert source._parser_failure_is_terminal is True
+    assert source.stats.zero_reason == ZeroYieldReason.POLICY_NOT_SCRAPED
+
+
+@pytest.mark.asyncio
+async def test_parser_terminal_error_does_not_fall_through_to_dom(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    from job_ftch.infrastructure.sources.career_site_source import ZeroYieldReason
+
+    source = CareerSiteSource(
+        spec=CareerSiteSpec(url="https://example.com/jobs", source_name="example"),
+        http_client=object(),
+        auth=MagicMock(),
+    )
+    source.bypass_strategy = _NoopBypass()
+    monkeypatch.setattr(
+        "job_ftch.application.registry.resolve_site_parser_for_spec",
+        lambda _: _TerminalErrorParser(),
+    )
+
+    with pytest.raises(TypeError, match="malformed API payload"):
+        _ = [item async for item in source._try_site_parser(object())]
+
+    assert source._parser_failure_is_terminal is True
+    assert source.stats.zero_reason == ZeroYieldReason.PARSER_ERROR
 
 
 def test_resolve_scraper_chain_prefers_json_ld_for_generic_and_dom() -> None:

--- a/tests/test_monitors.py
+++ b/tests/test_monitors.py
@@ -4,7 +4,12 @@ from job_ftch.application.contracts import BoardMonitor
 from job_ftch.domain.site_models import MonitorResult
 from job_ftch.domain.source_spec import CareerSiteSpec
 from job_ftch.infrastructure.sources.monitors.api_sniffer import discover as sniffer_discover
-from job_ftch.infrastructure.sources.monitors.dom import discover as dom_discover
+from job_ftch.infrastructure.sources.monitors.dom import (
+    _extract_links_rendered,
+)
+from job_ftch.infrastructure.sources.monitors.dom import (
+    discover as dom_discover,
+)
 
 
 @pytest.mark.asyncio
@@ -53,3 +58,30 @@ async def test_dom_monitor_uses_browser_search_prefetch() -> None:
     )
 
     assert any("/jobs/42" in url for url in result)
+
+
+@pytest.mark.asyncio
+async def test_dom_rendered_links_ignore_non_string_js_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Page:
+        async def content(self) -> str:
+            return "<html><title>Careers</title></html>"
+
+        async def evaluate(self, _expression: str) -> object:
+            return [["https://example.com/jobs/42"], "https://example.com/jobs/43", None]
+
+    async def _navigate(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    async def _run_actions(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    import job_ftch.infrastructure.sources.browser_utils as browser_utils
+
+    monkeypatch.setattr(browser_utils, "navigate", _navigate, raising=False)
+    monkeypatch.setattr(browser_utils, "run_actions", _run_actions, raising=False)
+
+    assert await _extract_links_rendered(_Page(), "https://example.com/careers", {}) == {
+        "https://example.com/jobs/43"
+    }

--- a/tests/test_release_deploy_contract.py
+++ b/tests/test_release_deploy_contract.py
@@ -95,6 +95,11 @@ def test_prod_bot_image_copies_current_source_over_runtime_base() -> None:
     text = TELEGRAM_DOCKERFILE_PROD.read_text(encoding="utf-8")
 
     assert "COPY --chown=appuser:appuser . /app" in text
+    assert "uv sync" not in text
+    assert "patchright install" not in text
+    assert "camoufox fetch" not in text
+    assert "cloakbrowser install" not in text
+    assert "chown -R" not in text
 
 
 def test_workflow_paths_exist() -> None:


### PR DESCRIPTION
## Summary
- harden browser cleanup and nodriver recovery
- classify source failures by actual outcome and preserve watchdog evidence
- slim production image build and verify browser runtime in both image variants
- make recovery coverage portable across Windows and Linux

## Verification
- PR #207 CI: all checks green
- local full suite: 3525 passed, 12 skipped
- local prod/dev images built; browser smoke passed
- filtering accuracy 0.8480, false-positive 0.2287 <= 0.25
- extraction field match 0.8561 >= 0.75
- 303-source Docker ingest: 218 parsed_ok (71.95%, gate >=65%)