### PR TITLE
fix: persist browser sessions in runtime storage

### DIFF
--- a/docs/adr/075-advanced-anti-bot-evasion-techniques.md
+++ b/docs/adr/075-advanced-anti-bot-evasion-techniques.md
@@ -106,7 +106,7 @@ Persist session state between runs to simulate "returning user":
 - Visit count and last visit timestamp
 - Behavioral profile (average reading time, scroll patterns)
 
-**Storage:** `data/session_memory/{persona_id}.json`
+**Storage:** `.runtime/session_memory/{persona_id}.json`
 
 **Integration:** Call `SessionMemory.capture_from_browser()` before browser
 close. Call `SessionMemory.apply_to_browser()` after browser open.

--- a/job_ftch/infrastructure/bypass/session_memory.py
+++ b/job_ftch/infrastructure/bypass/session_memory.py
@@ -23,7 +23,7 @@ import structlog
 
 logger = structlog.get_logger("job_ftch.bypass.session_memory")
 
-_DEFAULT_STORAGE_DIR = "data/session_memory"
+_DEFAULT_STORAGE_DIR = ".runtime/session_memory"
 _COOKIE_ALLOWLIST = frozenset({"cf_clearance", "cf_bm", "dd_cookie", "_px3", "datadome"})
 
 

--- a/job_ftch/infrastructure/sources/site_parsers/workxam.py
+++ b/job_ftch/infrastructure/sources/site_parsers/workxam.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import html
 import json
 import re
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 import structlog
@@ -61,13 +62,16 @@ class WorkxAmParser:
 
         emitted = 0
         for job in jobs:
+            if not isinstance(job, Mapping):
+                continue
             slug = job.get("slug")
             if not slug:
                 continue
 
             job_url = f"https://workx.am/jobs/{slug}"
             title = job.get("title", "")
-            company_name = job.get("company", {}).get("name", "")
+            company = job.get("company")
+            company_name = company.get("name", "") if isinstance(company, Mapping) else ""
 
             html_parts = [f"<h1>{title}</h1>"]
             if company_name:

--- a/tests/index.md
+++ b/tests/index.md
@@ -161,4 +161,5 @@ Generated index for navigation and maintenance. Rerun `uv run python scripts/bui
 - [test_triage.py](test_triage.py)
 - [test_url_scoring.py](test_url_scoring.py)
 - [test_watermark.py](test_watermark.py)
+- [test_workxam_site_parser.py](test_workxam_site_parser.py)
 - [test_yandex_site_parser.py](test_yandex_site_parser.py)

--- a/tests/infrastructure/bypass/test_adr075_advanced_evasion.py
+++ b/tests/infrastructure/bypass/test_adr075_advanced_evasion.py
@@ -219,6 +219,12 @@ class TestSessionMemory:
             assert memory2.state.visit_count == 5
             assert len(memory2.state.cookies) == 1
 
+    def test_default_storage_uses_runtime_directory(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        memory = SessionMemory("test_persona")
+        memory.save()
+        assert (tmp_path / ".runtime/session_memory/test_persona.json").is_file()
+
     def test_behavioral_profile_update(self):
         """Behavioral profile updates with exponential moving average."""
         memory = SessionMemory("test_persona")

--- a/tests/test_workxam_site_parser.py
+++ b/tests/test_workxam_site_parser.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import html
+import json
+
+import pytest
+
+from job_ftch.domain.source_spec import CareerSiteSpec
+from job_ftch.infrastructure.sources.site_parsers.workxam import WorkxAmParser
+
+
+class _Response:
+    def __init__(self, payload: dict[str, object]) -> None:
+        encoded = html.escape(json.dumps(payload), quote=True)
+        self.text = f'<div id="app" data-page="{encoded}"></div>'
+
+    def raise_for_status(self) -> None:
+        pass
+
+
+class _Client:
+    async def get(self, _url: str) -> _Response:
+        return _Response(
+            {
+                "props": {
+                    "jobs": [
+                        "unexpected-row",
+                        {"slug": "ai-engineer", "title": "AI Engineer", "company": "Hidden"},
+                    ]
+                }
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_workxam_ignores_non_object_rows() -> None:
+    spec = CareerSiteSpec(url="https://workx.am/", source_name="workx", limit=1)
+    items = [item async for item in WorkxAmParser().parse(spec, _Client())]
+    assert [str(item.url) for item in items] == ["https://workx.am/jobs/ai-engineer"]


### PR DESCRIPTION
## Summary
- persist anti-bot session memory in the mounted runtime directory
- tolerate malformed WorkX rows observed by the production ingest
- add regression coverage

## Verification
- 22 targeted tests passed
- Ruff and docs lint passed
- production Docker image verification in progress