### PR TITLE
fix: restore reliable career source listings

### DIFF
--- a/job_ftch/application/search_expansion.py
+++ b/job_ftch/application/search_expansion.py
@@ -7,8 +7,8 @@ whose resolved site parser has a verified search recipe is rewritten into one
 pre-filtered result page instead of the whole board.
 
 The assessment is attached to each prepared source before this function runs.
-Specific parser builders remain the runtime fallback when the generic HTML-form
-probe cannot assess an SPA/API search surface.
+Specific parser builders remain the fallback for callers without an assessment;
+assessed but unverified candidates stay at their original listing URL.
 """
 
 from __future__ import annotations
@@ -53,44 +53,34 @@ def expand_career_site_specs(
         if assessed_executor in {"generic_get", "generic_post", "generic_browser"}:
             expanded.append(_attach_search_keywords(spec, roles, base_url=base_url))
             continue
-        parser = resolve_site_parser_for_spec(spec)
-        # A failed generic-form probe must not suppress a deterministic search
-        # URL builder owned by a special parser.  The two mechanisms probe
-        # different surfaces: many SPA/API boards have no HTML <form> at all.
-        # Assessment remains telemetry; the parser builder is the runtime
-        # fallback requested by the source contract.
-        if parser is not None and getattr(parser, "supports_search", False):
-            try:
-                urls = list(parser.build_search_urls(spec.url, roles, limit=spec.limit))
-            except Exception as exc:  # noqa: BLE001 - never let expansion drop a source
-                logger.warning("search_expansion_failed", url=spec.url, error=str(exc))
-                urls = []
-            if urls:
-                for index, url in enumerate(urls):
-                    expanded.append(
-                        _clone_with_search_url(
-                            _attach_search_keywords(
-                                spec,
-                                roles,
-                                base_url=base_url,
-                                runtime_executor="specific_url",
-                            ),
-                            url,
-                            index,
-                            len(urls),
-                        )
-                    )
-                continue
         if assessed_status and assessed_status != "verified":
             expanded.append(_attach_search_keywords(spec, roles, base_url=base_url))
             continue
+        parser = resolve_site_parser_for_spec(spec)
         if parser is None or not getattr(parser, "supports_search", False):
             # Every career source carries the roles into runtime. A specific
             # parser may still be used after the generic search executor finds
             # a form or browser/API recipe.
             expanded.append(_attach_search_keywords(spec, roles, base_url=base_url))
             continue
-        expanded.append(_attach_search_keywords(spec, roles, base_url=base_url))
+        try:
+            urls = list(parser.build_search_urls(spec.url, roles, limit=spec.limit))
+        except Exception as exc:  # noqa: BLE001 - never let expansion drop a source
+            logger.warning("search_expansion_failed", url=spec.url, error=str(exc))
+            expanded.append(_attach_search_keywords(spec, roles, base_url=base_url))
+            continue
+        if not urls:
+            expanded.append(_attach_search_keywords(spec, roles, base_url=base_url))
+            continue
+        for index, url in enumerate(urls):
+            expanded.append(
+                _clone_with_search_url(
+                    _attach_search_keywords(spec, roles, base_url=base_url),
+                    url,
+                    index,
+                    len(urls),
+                )
+            )
     return expanded
 
 
@@ -106,13 +96,10 @@ def _attach_search_keywords(
     roles: list[str],
     *,
     base_url: str | None = None,
-    runtime_executor: str | None = None,
 ) -> SourceSpec:
     monitor_config = dict(getattr(spec, "monitor_config", {}) or {})
     monitor_config["_search_keywords"] = list(roles)
     monitor_config["_search_base_url"] = base_url or getattr(spec, "url", "")
-    if runtime_executor:
-        monitor_config["_search_runtime_executor"] = runtime_executor
     return spec.model_copy(update={"monitor_config": monitor_config})
 
 

--- a/job_ftch/infrastructure/sources/career_site_source.py
+++ b/job_ftch/infrastructure/sources/career_site_source.py
@@ -1785,13 +1785,15 @@ class CareerSiteSource(Source["RawItem"]):
         self.stats.search_query_mode = (
             assessment.get("query_mode") if isinstance(assessment, dict) else None
         )
+        if self.stats.search_status != "verified":
+            return
         base_url = str(self.spec.monitor_config.get("_search_base_url") or self.spec.url)
         if self.spec.search_locked or not base_url:
             return
         if runtime_executor == "specific_url" and self.spec.url != base_url:
             self.stats.search_applied = True
             return
-        if executor in {"specific_url", "specific_api"} and self.spec.url != base_url:
+        if executor in {"specific_url", "specific_api"}:
             return
         if executor == "generic_browser":
             await self._apply_generic_browser_search(

--- a/job_ftch/infrastructure/sources/site_parsers/getmatch.py
+++ b/job_ftch/infrastructure/sources/site_parsers/getmatch.py
@@ -645,8 +645,8 @@ class GetmatchParser:
     domain_pattern = _DOMAIN_PATTERN
     has_custom_parse = True
     supports_discover = False
-    supports_search = True
-    search_mode = "combined"
+    supports_search = False
+    search_mode = "none"
     # Authoritative empty UI is rare; SPA shell without cards is not empty.
     confirmed_empty_on_empty = True
     terminal_on_empty = False

--- a/job_ftch/infrastructure/sources/site_parsers/habr.py
+++ b/job_ftch/infrastructure/sources/site_parsers/habr.py
@@ -164,8 +164,8 @@ class HabrCareerParser:
     domain_pattern = r"^https?://career\.habr\.com/"
     has_custom_parse = True
     supports_discover = True
-    supports_search = True
-    search_mode = "combined"
+    supports_search = False
+    search_mode = "none"
 
     def build_search_urls(
         self,

--- a/job_ftch/infrastructure/sources/site_parsers/hirehi.py
+++ b/job_ftch/infrastructure/sources/site_parsers/hirehi.py
@@ -20,8 +20,8 @@ class HireHiParser:
 
     domain_pattern = r"^https?://(?:www\.)?hirehi\.ru(?:/|$)"
     has_custom_parse = False
-    supports_search = True
-    search_mode = "per_keyword"
+    supports_search = False
+    search_mode = "none"
 
     def runtime_defaults(self, url: str) -> SiteRuntimeDefaults:
         del url

--- a/tests/application/test_search_expansion.py
+++ b/tests/application/test_search_expansion.py
@@ -98,7 +98,7 @@ def test_source_without_search_parser_gets_runtime_keywords() -> None:
     assert out[0].monitor_config["_search_keywords"] == ROLES
 
 
-def test_unverified_assessment_still_applies_specific_builder(monkeypatch) -> None:
+def test_unverified_assessment_keeps_base_listing(monkeypatch) -> None:
     class Parser:
         supports_search = True
 
@@ -115,9 +115,8 @@ def test_unverified_assessment_still_applies_specific_builder(monkeypatch) -> No
         monitor_config={"_search_assessment": {"status": "unsupported", "executor": "none"}},
     )
     out = expand_career_site_specs([spec], ROLES)
-    assert out[0].url == "https://example.com/jobs?q=runtime-fallback"
+    assert out[0].url == "https://example.com/jobs"
     assert out[0].monitor_config["_search_keywords"] == ROLES
-    assert out[0].monitor_config["_search_runtime_executor"] == "specific_url"
 
 
 def test_per_keyword_clone_gets_unique_source_name() -> None:

--- a/tests/test_career_site_generic.py
+++ b/tests/test_career_site_generic.py
@@ -776,7 +776,7 @@ async def test_scrape_with_fallback_still_scrapes_200_job_html() -> None:
 
 
 @pytest.mark.asyncio
-async def test_maybe_apply_generic_search_does_not_skip_parser_without_search(
+async def test_maybe_apply_generic_search_skips_unassessed_recipe(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     spec = CareerSiteSpec(
@@ -809,11 +809,11 @@ async def test_maybe_apply_generic_search_does_not_skip_parser_without_search(
         _discover,
     )
     await source._maybe_apply_generic_search(object())
-    assert probed == ["https://www.superjob.ru/vacancy/search/"]
+    assert probed == []
 
 
 @pytest.mark.asyncio
-async def test_maybe_apply_generic_search_runs_for_parser_with_supports_search(
+async def test_maybe_apply_generic_search_skips_unverified_recipe(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     spec = CareerSiteSpec(
@@ -838,7 +838,39 @@ async def test_maybe_apply_generic_search_runs_for_parser_with_supports_search(
         _discover,
     )
     await source._maybe_apply_generic_search(object())
-    assert probed == ["https://hh.ru/search/vacancy"]
+    assert probed == []
+
+
+@pytest.mark.asyncio
+async def test_maybe_apply_generic_search_runs_for_verified_recipe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec = CareerSiteSpec(
+        url="https://example.com/jobs",
+        source_name="example",
+        monitor_config={
+            "_search_keywords": ["ML Engineer"],
+            "_search_assessment": {"status": "verified", "executor": "generic_get"},
+        },
+    )
+    source = CareerSiteSource(spec=spec, http_client=FakeHttpClient({}), auth=MagicMock())
+    probed: list[str] = []
+
+    async def _bypass(_http: object) -> object:
+        return object()
+
+    async def _discover(_fetch, url, keywords, log=None):  # type: ignore[no-untyped-def]
+        del _fetch, keywords, log
+        probed.append(url)
+        return None
+
+    monkeypatch.setattr(source, "_apply_bypass_http", _bypass)
+    monkeypatch.setattr(
+        "job_ftch.infrastructure.sources.site_parsers.generic_search.discover_working_search_url",
+        _discover,
+    )
+    await source._maybe_apply_generic_search(object())
+    assert probed == ["https://example.com/jobs"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_site_parser_search_urls.py
+++ b/tests/test_site_parser_search_urls.py
@@ -25,12 +25,14 @@ def _query(url: str) -> dict[str, list[str]]:
 
 
 def test_aggregators_declare_search_modes() -> None:
-    for parser in (HhParser(), HabrCareerParser(), HirifyParser(), VkTeamParser(), SberParser()):
+    for parser in (HhParser(), HirifyParser(), VkTeamParser(), SberParser()):
         assert parser.supports_search is True
         assert parser.search_mode == "combined"
-    for parser in (GeekJobParser(), HireHiParser()):
-        assert parser.supports_search is True
-        assert parser.search_mode == "per_keyword"
+    assert GeekJobParser().supports_search is True
+    assert GeekJobParser().search_mode == "per_keyword"
+    for parser in (HabrCareerParser(), HireHiParser()):
+        assert parser.supports_search is False
+        assert parser.search_mode == "none"
 
 
 def test_hh_builds_single_or_query_preserving_area() -> None:


### PR DESCRIPTION
## Summary
- keep unverified source-search recipes on their base listing
- restore Habr, Getmatch, and HireHi base-listing paths
- prevent unsupported Yandex browser search from consuming the source deadline

## Verification
- 3,528 tests passed; coverage 74.78%
- code-verify passed
- repo-safety scan and prepush passed
- production Docker images built locally
- targeted container ingest: Habr 5/5, Getmatch 5/5, HireHi 5/5, Yandex 4/5, GeekJob 4/5; all status ok
- container API health endpoints return ok