### PR TITLE
fix: route geo-blocked sources through regional proxy

### DIFF
--- a/job_ftch/infrastructure/bypass/failure_signal.py
+++ b/job_ftch/infrastructure/bypass/failure_signal.py
@@ -127,6 +127,9 @@ _IP_BLOCK_MARKERS: tuple[str, ...] = (
     "access from your ip",
     "too many requests from this ip",
     "proxy detected",
+    "international traffic",
+    "международный трафик",
+    "отключите vpn",
 )
 
 _FINGERPRINT_BLOCK_MARKERS: tuple[str, ...] = (

--- a/job_ftch/infrastructure/bypass/nodriver_bypass.py
+++ b/job_ftch/infrastructure/bypass/nodriver_bypass.py
@@ -606,9 +606,8 @@ class NodriverBypass:
         )
         if proxy_url:
             tab = await browser.create_context(
-                url="about:blank",
                 proxy_server=proxy_url,
-                proxy_bypass_list=["localhost"],
+                proxy_bypass_list="localhost",
             )
         else:
             tab = await browser.get("about:blank")

--- a/job_ftch/infrastructure/sources/career_site_source.py
+++ b/job_ftch/infrastructure/sources/career_site_source.py
@@ -853,7 +853,11 @@ class CareerSiteSource(Source["RawItem"]):
 
         initial_bypass = self.spec.bypass or "auto"
         bypass_config = dict(self.spec.bypass_config)
-        for config_key in ("proxy_rescue_allow_domains", "captcha_authorized_domains"):
+        for config_key in (
+            "proxy_rescue_allow_domains",
+            "captcha_authorized_domains",
+            "proxy_geo",
+        ):
             parser_domains = self.spec.monitor_config.get(config_key)
             if parser_domains:
                 bypass_config[config_key] = parser_domains
@@ -2151,7 +2155,9 @@ class CareerSiteSource(Source["RawItem"]):
                 continue
             if self._bypass_ctx:
                 self._bypass_ctx.record_success(candidate.url)
-            yield payload_to_raw_item(payload, self.spec, source_name)
+            item = payload_to_raw_item(payload, self.spec, source_name)
+            self.stats.zero_reason = None
+            yield item
 
         urls_to_scrape = {c.url for c in candidates if c.rich_payload is None}
         if not urls_to_scrape:
@@ -2179,6 +2185,7 @@ class CareerSiteSource(Source["RawItem"]):
         ranked_generic = _rank_detail_urls(urls_to_scrape - seen_trusted, self.spec.url)
         ranked = [*ranked_trusted, *ranked_generic]
         async for item in self._iter_scraped_detail_items(ranked, scraper_chain, source_name):
+            self.stats.zero_reason = None
             yield item
 
     async def _scrape_detail_url_to_raw_item(

--- a/job_ftch/infrastructure/sources/site_defaults.py
+++ b/job_ftch/infrastructure/sources/site_defaults.py
@@ -8,6 +8,7 @@ the spec URL and applies its `runtime_defaults(url)`.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 if TYPE_CHECKING:
     from job_ftch.domain.source_spec import CareerSiteSpec
@@ -76,6 +77,13 @@ def apply_runtime_defaults(spec: CareerSiteSpec) -> CareerSiteSpec:
 
     monitor_config = dict(default_monitor_config)
     monitor_config.update(spec.monitor_config)
+    country_tld = (urlparse(str(spec.url)).hostname or "").rsplit(".", 1)[-1]
+    if (
+        "proxy_rescue_allow_domains" in monitor_config
+        and "proxy_geo" not in monitor_config
+        and len(country_tld) == 2
+    ):
+        monitor_config["proxy_geo"] = country_tld.upper()
 
     url_filter = spec.url_filter
     if url_filter is None:

--- a/tests/infrastructure/bypass/test_failure_signal_classification.py
+++ b/tests/infrastructure/bypass/test_failure_signal_classification.py
@@ -44,6 +44,12 @@ from job_ftch.infrastructure.bypass.failure_signal import (
         (402, b"Payment Required", None, FailureKind.PAYMENT_REQUIRED),
         (498, b"Anti-bot block", None, FailureKind.BLOCKED),
         (499, b"Client Closed Request", None, FailureKind.BLOCKED),
+        (
+            200,
+            "Отключите VPN: международный трафик временно ограничен".encode(),
+            None,
+            FailureKind.BLOCKED_IP,
+        ),
     ],
 )
 def test_failure_signal_classifies_challenge_and_transport_patterns(

--- a/tests/test_bypass.py
+++ b/tests/test_bypass.py
@@ -372,12 +372,10 @@ async def test_nodriver_bypass_preserves_browser_config(
         async def create_context(
             self,
             *,
-            url: str,
             proxy_server: str,
-            proxy_bypass_list: list[str],
+            proxy_bypass_list: str,
         ) -> _FakeTab:
             captured["proxy_context"] = {
-                "url": url,
                 "proxy_server": proxy_server,
                 "proxy_bypass_list": proxy_bypass_list,
             }
@@ -442,9 +440,8 @@ async def test_nodriver_bypass_preserves_browser_config(
         "lang": "en-US",
     }
     assert captured["proxy_context"] == {
-        "url": "about:blank",
         "proxy_server": "http://proxy.local:8080",
-        "proxy_bypass_list": ["localhost"],
+        "proxy_bypass_list": "localhost",
     }
     assert captured["window_size"] == (0, 0, 1440, 900)
 

--- a/tests/test_career_site_generic.py
+++ b/tests/test_career_site_generic.py
@@ -1001,6 +1001,7 @@ async def test_parser_captcha_allowlist_reaches_bypass_config(monkeypatch):
             monitor_config={
                 "captcha_authorized_domains": ["jobs.ashbyhq.com"],
                 "proxy_rescue_allow_domains": ["jobs.ashbyhq.com"],
+                "proxy_geo": "US",
             },
         ),
         http_client=object(),
@@ -1012,6 +1013,7 @@ async def test_parser_captcha_allowlist_reaches_bypass_config(monkeypatch):
     assert captured["name"] == "auto"
     assert captured["config"]["captcha_authorized_domains"] == ["jobs.ashbyhq.com"]
     assert captured["config"]["proxy_rescue_allow_domains"] == ["jobs.ashbyhq.com"]
+    assert captured["config"]["proxy_geo"] == "US"
 
 
 @pytest.mark.asyncio

--- a/tests/test_fetch_universal_career_source.py
+++ b/tests/test_fetch_universal_career_source.py
@@ -91,6 +91,15 @@ def test_browser_challenge_is_not_a_listing_page() -> None:
         )
 
 
+def test_geo_block_page_is_not_a_listing_page() -> None:
+    with pytest.raises(BrowserChallengeError):
+        raise_if_browser_challenge(
+            "<html><title>Отключите VPN</title><body>"
+            "Доступ ограничен: международный трафик временно отключён.</body></html>",
+            url="https://job.beeline.ru/vacancies",
+        )
+
+
 class _DatedSiteParser:
     has_custom_parse = True
     supports_discover = False

--- a/tests/test_site_defaults.py
+++ b/tests/test_site_defaults.py
@@ -137,6 +137,9 @@ def test_protected_parser_defaults_declare_only_authorized_domains() -> None:
         ]
         assert config["proxy_rescue_allow_domains"] == config["captcha_authorized_domains"]
 
+    beeline = apply_runtime_defaults(CareerSiteSpec(url="https://job.beeline.ru/vacancies"))
+    assert beeline.monitor_config["proxy_geo"] == "RU"
+
     superjob = apply_runtime_defaults(CareerSiteSpec(url="https://www.superjob.ru/vakansii/"))
     assert superjob.monitor_config["captcha_authorized_domains"] == [
         "www.superjob.ru",


### PR DESCRIPTION
## What changed
- classify explicit international/VPN blocking pages as BLOCKED_IP
- infer proxy region from the source TLD only for existing proxy-rescue allowlisted adapters
- pass regional proxy configuration through CareerSiteSource
- use CDP-compatible nodriver proxy context parameters
- clear stale monitor_empty state once an item is actually emitted

## Verification
- focused tests: 130 passed
- local production Docker image: 13/13 problem sources parsed successfully
- ai-repo-safety scan and prepush: passed