### PR TITLE
fix: make OpenObserve dashboard importable

### DIFF
--- a/deploy/observability/dashboards/job_ftch_ingest.json
+++ b/deploy/observability/dashboards/job_ftch_ingest.json
@@ -108,6 +108,7 @@
           "id": "source-health-counts",
           "type": "stacked",
           "title": "Источники ok vs fail",
+          "description": "Среднее число успешных и проблемных источников по прогонам",
           "queryType": "sql",
           "queries": [
             {
@@ -135,6 +136,7 @@
           "id": "funnel",
           "type": "line",
           "title": "Воронка fetched / extracted / emitted",
+          "description": "Динамика основных этапов воронки по прогонам",
           "queryType": "sql",
           "queries": [
             {
@@ -219,6 +221,7 @@
           "id": "status-pie",
           "type": "pie",
           "title": "Статусы источников в прогоне",
+          "description": "Распределение статусов источников в выбранном прогоне",
           "queryType": "sql",
           "queries": [
             {
@@ -243,6 +246,7 @@
           "id": "kind-bar",
           "type": "bar",
           "title": "Типы источников: emitted",
+          "description": "Yield и emitted по типам источников в выбранном прогоне",
           "queryType": "sql",
           "queries": [
             {

--- a/job_ftch/infrastructure/observability/dashboards/job_ftch_ingest.json
+++ b/job_ftch/infrastructure/observability/dashboards/job_ftch_ingest.json
@@ -108,6 +108,7 @@
           "id": "source-health-counts",
           "type": "stacked",
           "title": "Источники ok vs fail",
+          "description": "Среднее число успешных и проблемных источников по прогонам",
           "queryType": "sql",
           "queries": [
             {
@@ -135,6 +136,7 @@
           "id": "funnel",
           "type": "line",
           "title": "Воронка fetched / extracted / emitted",
+          "description": "Динамика основных этапов воронки по прогонам",
           "queryType": "sql",
           "queries": [
             {
@@ -219,6 +221,7 @@
           "id": "status-pie",
           "type": "pie",
           "title": "Статусы источников в прогоне",
+          "description": "Распределение статусов источников в выбранном прогоне",
           "queryType": "sql",
           "queries": [
             {
@@ -243,6 +246,7 @@
           "id": "kind-bar",
           "type": "bar",
           "title": "Типы источников: emitted",
+          "description": "Yield и emitted по типам источников в выбранном прогоне",
           "queryType": "sql",
           "queries": [
             {

--- a/tests/infrastructure/observability/test_openobserve.py
+++ b/tests/infrastructure/observability/test_openobserve.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
 import logging
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 from structlog.contextvars import bind_contextvars, reset_contextvars
 
@@ -23,6 +25,16 @@ def test_openobserve_url_rejects_non_http_schemes() -> None:
     assert _resolve_openobserve_url("https://observe.example/") == "https://observe.example"
     with pytest.raises(ValueError, match="http or https"):
         _resolve_openobserve_url("file:///tmp/dashboard")
+
+
+def test_openobserve_dashboard_copies_match_and_panels_have_descriptions() -> None:
+    root = Path(__file__).parents[3]
+    packaged = root / "job_ftch/infrastructure/observability/dashboards/job_ftch_ingest.json"
+    deploy = root / "deploy/observability/dashboards/job_ftch_ingest.json"
+
+    assert packaged.read_bytes() == deploy.read_bytes()
+    dashboard = json.loads(packaged.read_text(encoding="utf-8"))
+    assert all(panel.get("description") for tab in dashboard["tabs"] for panel in tab["panels"])
 
 
 def test_context_filter_promotes_only_safe_correlation_fields() -> None:


### PR DESCRIPTION
## Summary
- add the panel descriptions required by OpenObserve v0.90.3
- keep packaged and deployment dashboard copies identical
- add a regression check for required descriptions

## Verification
- focused tests: 5 passed
- live OpenObserve import: 3 tabs, 13 panels
- repo safety scan and pre-push gate passed