### PR TITLE
fix: harden vacancy parsers and ontology projection

### DIFF
--- a/job_ftch/adapters/telegram_bot/api.py
+++ b/job_ftch/adapters/telegram_bot/api.py
@@ -133,6 +133,9 @@ async def _tenant_health(runner: TenantRunner, tenant_id: str) -> dict[str, Any]
                 "bot_scheduler:last_publish_error",
                 "bot_scheduler:last_publish_sent",
                 "bot_scheduler:pending_publish_since",
+                "bot_scheduler:last_owner_report_attempt_at",
+                "bot_scheduler:last_owner_report_success_at",
+                "bot_scheduler:last_owner_report_error",
             )
         }
     except Exception as exc:
@@ -151,7 +154,14 @@ async def _tenant_health(runner: TenantRunner, tenant_id: str) -> dict[str, Any]
     watch_sources = [item for item in source_health if item.quality_important]
     scheduler_error = str(scheduler_state.get("bot_scheduler:last_error") or "").strip()
     publish_error = str(scheduler_state.get("bot_scheduler:last_publish_error") or "").strip()
-    status = "degraded" if bad_sources or scheduler_error or publish_error else "ok"
+    owner_report_error = str(
+        scheduler_state.get("bot_scheduler:last_owner_report_error") or ""
+    ).strip()
+    status = (
+        "degraded"
+        if bad_sources or scheduler_error or publish_error or owner_report_error
+        else "ok"
+    )
     last_finished = summary.finished_at.isoformat() if summary and summary.finished_at else None
     return {
         "tenant_id": tenant_id,
@@ -194,6 +204,13 @@ async def _tenant_health(runner: TenantRunner, tenant_id: str) -> dict[str, Any]
             "pending_age_seconds": _age_seconds(
                 scheduler_state.get("bot_scheduler:pending_publish_since")
             ),
+        },
+        "owner_report": {
+            "last_attempt_at": scheduler_state.get("bot_scheduler:last_owner_report_attempt_at")
+            or None,
+            "last_success_at": scheduler_state.get("bot_scheduler:last_owner_report_success_at")
+            or None,
+            "last_error": owner_report_error or None,
         },
     }
 

--- a/job_ftch/adapters/telegram_bot/main.py
+++ b/job_ftch/adapters/telegram_bot/main.py
@@ -45,6 +45,7 @@ from job_ftch.application.vacancy_feedback import is_feedback_enabled
 
 if TYPE_CHECKING:
     from job_ftch.adapters.telegram_bot.config import TelegramBotConfig
+    from job_ftch.application.contracts import Store
     from job_ftch.application.tenant_runner import TenantRunner
 
 logger = structlog.get_logger(__name__)
@@ -287,6 +288,7 @@ async def _recover_pending_scheduler_publish(
 async def _send_scheduler_run_report(
     bot: Bot,
     *,
+    store: Store,
     tenant_id: str,
     publish_user_id: object,
     run_result: object,
@@ -298,6 +300,14 @@ async def _send_scheduler_run_report(
     user_chat_id = str(publish_user_id).strip()
     if not user_chat_id:
         return
+    try:
+        await _maybe_await(
+            store.set_run_state(
+                "bot_scheduler:last_owner_report_attempt_at", datetime.now(UTC).isoformat()
+            )
+        )
+    except Exception as exc:
+        logger.warning("scheduler_owner_report_state_failed", tenant_id=tenant_id, error=str(exc))
     report = build_runtime_run_report(run_result, duration_seconds=duration_seconds)
     footer = render_runtime_run_footer(report)
     text = f"✅ Автозапуск готов  {footer}\n\n{render_runtime_run_report_text(report)}"
@@ -310,12 +320,34 @@ async def _send_scheduler_run_report(
     try:
         await bot.send_message(user_chat_id, text, parse_mode="HTML")
     except Exception as exc:
+        try:
+            await _maybe_await(
+                store.set_run_state("bot_scheduler:last_owner_report_error", str(exc))
+            )
+        except Exception as state_exc:
+            logger.warning(
+                "scheduler_owner_report_state_failed",
+                tenant_id=tenant_id,
+                error=str(state_exc),
+            )
         logger.warning(
             "scheduler_owner_report_failed",
             tenant_id=tenant_id,
             user_id=user_chat_id,
             error=str(exc),
         )
+    else:
+        try:
+            await _maybe_await(
+                store.set_run_state(
+                    "bot_scheduler:last_owner_report_success_at", datetime.now(UTC).isoformat()
+                )
+            )
+            await _maybe_await(store.set_run_state("bot_scheduler:last_owner_report_error", ""))
+        except Exception as exc:
+            logger.warning(
+                "scheduler_owner_report_state_failed", tenant_id=tenant_id, error=str(exc)
+            )
 
 
 async def _send_scheduler_failure_report(
@@ -997,6 +1029,7 @@ async def _run_scheduler_loop(runner: TenantRunner, bot: Bot) -> None:
                         )
                     await _send_scheduler_run_report(
                         bot,
+                        store=store,
                         tenant_id=tenant_id,
                         publish_user_id=publish_user_id,
                         run_result=run_result,

--- a/job_ftch/application/ontology_compiler.py
+++ b/job_ftch/application/ontology_compiler.py
@@ -537,6 +537,7 @@ def _normalize_classify_result(raw: Any, schema: type[Any]) -> Any | None:
     return raw
 
 
+_CANDIDATE_PASS_MAX_TOKENS = 12000
 _COMPILE_PASS_MAX_TOKENS = 12000
 
 
@@ -559,6 +560,7 @@ async def _extract_candidate_chunk(
         LLMOntologyCandidateChunk,
         prompt_parts,
         timeout_seconds=compile_timeout,
+        max_tokens=_CANDIDATE_PASS_MAX_TOKENS,
     )
     if candidate is None:
         return None, tuple(prompt_parts)
@@ -588,6 +590,7 @@ async def _extract_candidate_chunk(
                 LLMOntologyCandidateChunk,
                 prompt_parts,
                 timeout_seconds=compile_timeout,
+                max_tokens=_CANDIDATE_PASS_MAX_TOKENS,
             )
             if rescued is not None:
                 rescued = _reattach_chunk_evidence(rescued, (shot,))
@@ -1372,6 +1375,7 @@ async def compile_ontology_from_shots(
                 LLMOntologyCandidateChunk,
                 prompt_parts,
                 timeout_seconds=compile_timeout,
+                max_tokens=_CANDIDATE_PASS_MAX_TOKENS,
             )
             if coverage is None:
                 consecutive_failures += 1

--- a/job_ftch/application/run_report.py
+++ b/job_ftch/application/run_report.py
@@ -7,6 +7,7 @@ or API surfaces can render the same run signal consistently.
 
 from __future__ import annotations
 
+import html
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -156,13 +157,14 @@ def render_runtime_run_report_text(report: RuntimeRunReport) -> str:
     text = "\n".join(funnel_parts)
     if report.notable_drop_reasons:
         reasons_str = ", ".join(
-            f"{reason.replace('_', ' ')}: {count}"
+            f"{html.escape(reason.replace('_', ' '), quote=True)}: {count}"
             for reason, count in report.notable_drop_reasons.items()
         )
         text += f"\n<i>Причины дропа: {reasons_str}</i>"
     if report.source_failures:
         problem_lines = [
-            f"{item.get('source_name') or item.get('source_id')}: {item.get('error')}"
+            f"{html.escape(str(item.get('source_name') or item.get('source_id') or ''), quote=True)}: "
+            f"{html.escape(str(item.get('error') or ''), quote=True)}"
             for item in report.source_failures
         ]
         text += "\n<i>Проблемные источники: " + "; ".join(problem_lines) + "</i>"

--- a/job_ftch/application/tenant_runner.py
+++ b/job_ftch/application/tenant_runner.py
@@ -934,6 +934,15 @@ class TenantRunner:
             "last_publish_skipped_reason": await _read_runtime_state(
                 runtime, "bot_scheduler:last_publish_skipped_reason"
             ),
+            "last_owner_report_attempt_at": await _read_runtime_state(
+                runtime, "bot_scheduler:last_owner_report_attempt_at"
+            ),
+            "last_owner_report_success_at": await _read_runtime_state(
+                runtime, "bot_scheduler:last_owner_report_success_at"
+            ),
+            "last_owner_report_error": await _read_runtime_state(
+                runtime, "bot_scheduler:last_owner_report_error"
+            ),
         }
 
     async def update_posting_config(self, tenant_id: str, channel: str) -> None:

--- a/job_ftch/infrastructure/sources/site_parsers/aggregator_boards.py
+++ b/job_ftch/infrastructure/sources/site_parsers/aggregator_boards.py
@@ -306,7 +306,8 @@ class AgileFluentParser(HtmlAggregatorParser):
         page_size = min(50, max(limit, 1))
         emitted = 0
         seen: set[str] = set()
-        for page in range(1, DEFAULT_LISTING_MAX_PAGES + 1):
+        page = 1
+        while True:
             try:
                 response = await client.post(
                     self._API_URL,
@@ -360,6 +361,9 @@ class AgileFluentParser(HtmlAggregatorParser):
             has_more = bool(payload.get("hasMore")) if isinstance(payload, dict) else False
             if not has_more:
                 return
+            if not rows:
+                return
+            page += 1
 
 
 class QuickOfferParser(HtmlAggregatorParser):

--- a/job_ftch/infrastructure/sources/site_parsers/habr.py
+++ b/job_ftch/infrastructure/sources/site_parsers/habr.py
@@ -322,6 +322,12 @@ class HabrCareerParser:
         keywords = keywords_from_spec(spec)
         seen_ids: set[str] = set()
         emitted = 0
+        detail_limit = spec.detail_limit
+        if detail_limit is None:
+            from job_ftch.config import get_settings
+
+            detail_limit = get_settings().career_site_default_detail_limit
+        detail_requests = 0
         for page in range(1, self._page_count(limit) + 1):
             listing_url = self._listing_page_url(spec.url, page)
             try:
@@ -336,7 +342,20 @@ class HabrCareerParser:
                 if not item_id or item_id in seen_ids:
                     continue
                 seen_ids.add(item_id)
-                yield item
+                detail_item = None
+                if detail_limit is None or detail_requests < detail_limit:
+                    detail_requests += 1
+                    try:
+                        detail_response = await safe_fetch(client, str(item.url))
+                        detail_item = _item_from_detail_html(
+                            str(getattr(detail_response, "url", item.url) or item.url),
+                            str(detail_response.text),
+                            source_name,
+                            spec.url,
+                        )
+                    except Exception as exc:  # noqa: BLE001 - keep the listing fallback
+                        logger.debug("habr.detail_fetch_failed", url=str(item.url), error=str(exc))
+                yield detail_item or item
                 emitted += 1
                 if emitted >= limit:
                     return

--- a/job_ftch/infrastructure/sources/site_parsers/hh.py
+++ b/job_ftch/infrastructure/sources/site_parsers/hh.py
@@ -59,7 +59,6 @@ _URL_FILTER = (
     r"(?:[a-z0-9-]+\.)?(?:hh\.(?:ru|kz|uz|by)|hh1\.az|headhunter\.kg|rabota\.by)/vacancy/\d+"
 )
 _LISTING_TIMESTAMP_RE = re.compile(r'"publicationTime"\s*:\s*\{[^}]*"@timestamp"\s*:\s*(\d+)')
-_MAX_DETAIL_REQUESTS = 10
 _PROXY_DOMAINS = [
     "hh.ru",
     "hh.kz",
@@ -473,9 +472,14 @@ class HhParser:
                 logger.debug("hh.browser_discover_failed", url=spec.url, error=str(exc))
 
         seen_final_ids: set[str] = set()
+        detail_limit = spec.detail_limit
+        if detail_limit is None:
+            from job_ftch.config import get_settings
+
+            detail_limit = get_settings().career_site_default_detail_limit
         detail_requests = 0
         for detail_url in collected_urls[:limit]:
-            if detail_requests >= _MAX_DETAIL_REQUESTS:
+            if detail_limit is not None and detail_requests >= detail_limit:
                 snapshot = listing_snapshots.get(_detail_identity(detail_url))
                 if snapshot:
                     yield _item_from_listing(detail_url, *snapshot, source_name, spec.url)

--- a/job_ftch/infrastructure/sources/site_parsers/hirehi.py
+++ b/job_ftch/infrastructure/sources/site_parsers/hirehi.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import html
 import json
 import re
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urljoin, urlparse, urlunparse
+from urllib.parse import parse_qsl, urlencode, urljoin, urlparse, urlunparse
 
 from selectolax.lexbor import LexborHTMLParser
 
@@ -25,6 +26,17 @@ if TYPE_CHECKING:
     from job_ftch.domain.source_spec import CareerSiteSpec
 
 _URL_FILTER = r"hirehi\.ru/[a-z0-9-]+/[a-z0-9-]+-\d+/?$"
+
+
+def _job_posting(html_text: str) -> dict[str, Any] | None:
+    for script in LexborHTMLParser(html_text).css('script[type="application/ld+json"]'):
+        try:
+            value = json.loads(script.text())
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if isinstance(value, dict) and value.get("@type") == "JobPosting":
+            return value
+    return None
 
 
 class HireHiParser:
@@ -56,47 +68,74 @@ class HireHiParser:
         return None
 
     async def parse(self, spec: CareerSiteSpec, client: Any) -> AsyncIterator[RawItem]:
-        response = await client.get(spec.url, follow_redirects=True)
-        response.raise_for_status()
-        base_url = str(getattr(response, "url", spec.url) or spec.url)
         limit = spec.limit or 50
         detail_re = re.compile(_URL_FILTER, re.IGNORECASE)
         seen: set[str] = set()
-        for node in LexborHTMLParser(str(response.text)).css('script[type="application/ld+json"]'):
-            try:
-                payload = json.loads(node.text())
-            except (TypeError, json.JSONDecodeError):
-                continue
-            elements = payload.get("itemListElement", []) if isinstance(payload, dict) else []
-            if not isinstance(elements, list):
-                continue
-            for element in elements:
-                if not isinstance(element, dict):
+        page = 1
+        while len(seen) < limit:
+            parsed = urlparse(spec.url)
+            query = dict(parse_qsl(parsed.query, keep_blank_values=True))
+            if page > 1:
+                query["page"] = str(page)
+            page_url = urlunparse(parsed._replace(query=urlencode(query)))
+            response = await client.get(page_url, follow_redirects=True)
+            response.raise_for_status()
+            base_url = str(getattr(response, "url", page_url) or page_url)
+            found = 0
+            for node in LexborHTMLParser(str(response.text)).css(
+                'script[type="application/ld+json"]'
+            ):
+                try:
+                    payload = json.loads(node.text())
+                except (TypeError, json.JSONDecodeError):
                     continue
-                item = element.get("item") if isinstance(element.get("item"), dict) else element
-                if not isinstance(item, dict):
+                elements = payload.get("itemListElement", []) if isinstance(payload, dict) else []
+                if not isinstance(elements, list):
                     continue
-                url = urljoin(base_url, str(item.get("url") or ""))
-                if not detail_re.search(url) or url in seen:
-                    continue
-                title = str(item.get("name") or "").strip()
-                if not title:
-                    continue
-                seen.add(url)
-                yield build_raw_item(
-                    source_kind=SourceKind.CAREER_SITE,
-                    source_name=spec.source_name or "hirehi",
-                    external_id=url.rstrip("/").rsplit("/", 1)[-1],
-                    url=url,
-                    text=title,
-                    metadata={
-                        "parser": "hirehi",
-                        "board_url": spec.url,
-                        "detail_vacancy_confirmed": True,
-                    },
-                )
-                if len(seen) >= limit:
-                    return
+                for element in elements:
+                    if not isinstance(element, dict):
+                        continue
+                    item = element.get("item") if isinstance(element.get("item"), dict) else element
+                    if not isinstance(item, dict):
+                        continue
+                    url = urljoin(base_url, str(item.get("url") or ""))
+                    if not detail_re.search(url) or url in seen:
+                        continue
+                    seen.add(url)
+                    found += 1
+                    try:
+                        detail = await client.get(url, follow_redirects=True)
+                        detail.raise_for_status()
+                        posting = _job_posting(str(detail.text))
+                    except Exception:  # noqa: BLE001 - preserve the listing fallback
+                        posting = None
+                    title = str((posting or item).get("title") or item.get("name") or "").strip()
+                    description = " ".join(
+                        LexborHTMLParser(
+                            f"<div>{html.unescape(str((posting or {}).get('description') or ''))}</div>"
+                        )
+                        .text(separator=" ", strip=True)
+                        .split()
+                    )
+                    if not title:
+                        continue
+                    yield build_raw_item(
+                        source_kind=SourceKind.CAREER_SITE,
+                        source_name=spec.source_name or "hirehi",
+                        external_id=url.rstrip("/").rsplit("/", 1)[-1],
+                        url=url,
+                        text="\n".join(part for part in (title, description) if part),
+                        metadata={
+                            "parser": "hirehi",
+                            "board_url": spec.url,
+                            "detail_vacancy_confirmed": posting is not None,
+                        },
+                    )
+                    if len(seen) >= limit:
+                        return
+            if found == 0:
+                return
+            page += 1
 
     def build_search_urls(
         self,

--- a/job_ftch/infrastructure/sources/site_parsers/hirify.py
+++ b/job_ftch/infrastructure/sources/site_parsers/hirify.py
@@ -364,23 +364,34 @@ class HirifyParser:
         client: Any,
         html: str,
     ) -> list[dict[str, Any]]:
-        response = await fetch_with_retry(
-            client,
-            self._api_url(html),
-            params=self._query_for_spec(spec),
-            headers={
-                "Accept": "application/json, text/plain, */*",
-                "Referer": spec.url,
-                "Origin": "https://hirify.me",
-            },
-            follow_redirects=True,
-        )
-        if response.status_code == 429:
-            raise HirifyRateLimitedError("429 Too many requests from hirify api")
-        response.raise_for_status()
-        payload = response.json()
-        data = payload.get("data") if isinstance(payload, dict) else None
-        return [row for row in data if isinstance(row, dict)] if isinstance(data, list) else []
+        rows: list[dict[str, Any]] = []
+        page = 1
+        limit = spec.limit or 50
+        while len(rows) < limit:
+            response = await fetch_with_retry(
+                client,
+                self._api_url(html),
+                params={**self._query_for_spec(spec), "page": str(page)},
+                headers={
+                    "Accept": "application/json, text/plain, */*",
+                    "Referer": spec.url,
+                    "Origin": "https://hirify.me",
+                },
+                follow_redirects=True,
+            )
+            if response.status_code == 429:
+                raise HirifyRateLimitedError("429 Too many requests from hirify api")
+            response.raise_for_status()
+            payload = response.json()
+            data = payload.get("data") if isinstance(payload, dict) else None
+            page_rows = (
+                [row for row in data if isinstance(row, dict)] if isinstance(data, list) else []
+            )
+            rows.extend(page_rows)
+            if not page_rows or not payload.get("next_page_url"):
+                break
+            page += 1
+        return rows[:limit]
 
     async def _fetch_detail_body(
         self,

--- a/job_ftch/infrastructure/sources/site_parsers/kaspi.py
+++ b/job_ftch/infrastructure/sources/site_parsers/kaspi.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin, urlparse, urlunparse
@@ -158,6 +159,36 @@ class KaspiParser:
             identity=lambda item: item.url,
         )
         for item in items:
+            try:
+                response = await safe_fetch(client, str(item.url))
+                posting = next(
+                    (
+                        value
+                        for node in LexborHTMLParser(str(response.text)).css(
+                            'script[type="application/ld+json"]'
+                        )
+                        if isinstance((value := json.loads(node.text())), dict)
+                        and value.get("@type") == "JobPosting"
+                    ),
+                    None,
+                )
+                description = ""
+                if posting:
+                    description = " ".join(
+                        LexborHTMLParser(f"<div>{posting.get('description') or ''}</div>")
+                        .text(separator=" ", strip=True)
+                        .split()
+                    )
+                if description and description.casefold() not in item.text.casefold():
+                    yield item.model_copy(
+                        update={
+                            "text": f"{item.text}\n{description}",
+                            "metadata": {**item.metadata, "detail_vacancy_confirmed": True},
+                        }
+                    )
+                    continue
+            except Exception:  # noqa: BLE001 - preserve useful listing evidence
+                pass
             yield item
 
     @property

--- a/job_ftch/infrastructure/sources/site_parsers/vk.py
+++ b/job_ftch/infrastructure/sources/site_parsers/vk.py
@@ -7,7 +7,11 @@ import re
 from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qs, urlencode, urljoin, urlsplit
 
+from selectolax.lexbor import LexborHTMLParser
+
 from job_ftch.application.registry import known_board_assessment_hint, register_site_parser
+from job_ftch.domain import SourceKind
+from job_ftch.infrastructure.sources.raw_item_factory import build_raw_item
 from job_ftch.infrastructure.sources.site_parsers.base import SiteRuntimeDefaults
 from job_ftch.infrastructure.sources.site_parsers.helpers import (
     normalize_search_keywords,
@@ -17,6 +21,9 @@ from job_ftch.infrastructure.sources.site_parsers.helpers import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from job_ftch.domain.models import RawItem
     from job_ftch.domain.source_spec import CareerSiteSpec
 
 
@@ -101,6 +108,32 @@ class VkTeamParser:
                 break
             offset += len(results)
         return urls
+
+    async def parse(self, spec: CareerSiteSpec, client: Any) -> AsyncIterator[RawItem]:
+        for url in await self.discover(spec, client):
+            try:
+                response = await safe_fetch(client, url)
+            except Exception:  # noqa: BLE001 - let the generic path recover on empty
+                continue
+            article = LexborHTMLParser(str(response.text)).css_first(".article")
+            text = " ".join(article.text(separator=" ", strip=True).split()) if article else ""
+            if not text:
+                continue
+            vacancy_id = url.rstrip("/").rsplit("/", 1)[-1]
+            yield build_raw_item(
+                source_kind=SourceKind.CAREER_SITE,
+                source_name=spec.source_name or "vk_team",
+                external_id=vacancy_id,
+                url=url,
+                text=text,
+                metadata={
+                    "board_url": spec.url,
+                    "parser": "vk_team",
+                    "company": "VK",
+                    "company_authoritative": True,
+                    "detail_vacancy_confirmed": True,
+                },
+            )
 
     @property
     def __name__(self) -> str:

--- a/job_ftch/infrastructure/sources/site_parsers/yandex.py
+++ b/job_ftch/infrastructure/sources/site_parsers/yandex.py
@@ -210,11 +210,12 @@ class YandexJobsParser:
         client: Any,
         listing_url: str,
         limit: int,
+        search_text: str = "",
     ) -> list[dict[str, Any]]:
         origin = urlparse(listing_url)
         api_url = urlunparse(origin._replace(path=self._api_path(), query="", fragment=""))
         page_size = min(max(limit, 1), 50)
-        text = self._search_text(listing_url)
+        text = search_text or self._search_text(listing_url)
         collected: list[dict[str, Any]] = []
         seen: set[str] = set()
         for page in range(1, 6):
@@ -288,11 +289,15 @@ class YandexJobsParser:
 
         emitted = 0
         emitted_urls: set[str] = set()
-        search_text = self._search_text(listing_url)
+        search_text = self._search_text(listing_url) or " OR ".join(
+            normalize_search_keywords(keywords_from_spec(spec))
+        )
         # ``text=`` already narrowed the API/listing. Re-filtering titles
         # against that query drops valid cards (``Data Analyst`` vs ``ai``).
         keywords = [] if search_text else keywords_from_spec(spec)
-        for payload in await self._publications_from_api(client, listing_url, limit):
+        for payload in await self._publications_from_api(
+            client, listing_url, limit, search_text=search_text
+        ):
             api_item = _item_from_api(payload, listing_url, source_name)
             if api_item is None or str(api_item.url) in emitted_urls:
                 continue

--- a/scripts/mvp_data_repair.py
+++ b/scripts/mvp_data_repair.py
@@ -284,7 +284,6 @@ async def rebuild_ontology(*, apply: bool, staging_artifact: Path | None = None)
             for chunk in manifest.get("candidate_chunks", ())
         )
         if candidate_chunks:
-            ontology = ontology.model_copy(update={"terms": ()})
             ontology = sanitize_compiled_ontology(
                 _restore_projection_from_candidates(
                     ontology,

--- a/tests/application/index.md
+++ b/tests/application/index.md
@@ -56,6 +56,7 @@ Generated index for navigation and maintenance. Rerun `uv run python scripts/bui
 - [test_resolver_queue.py](test_resolver_queue.py)
 - [test_run_budget.py](test_run_budget.py)
 - [test_run_data_reset.py](test_run_data_reset.py)
+- [test_run_report_html.py](test_run_report_html.py)
 - [test_run_stats.py](test_run_stats.py)
 - [test_runtime_lifecycle.py](test_runtime_lifecycle.py)
 - [test_runtime_ontology_priority.py](test_runtime_ontology_priority.py)

--- a/tests/application/test_ontology_compiler.py
+++ b/tests/application/test_ontology_compiler.py
@@ -105,6 +105,7 @@ class _ScriptedLLM:
         self.calls = 0
         self.prompts: list[str] = []
         self.timeouts: list[float | None] = []
+        self.token_limits: list[int | None] = []
 
     async def classify(
         self,
@@ -114,10 +115,11 @@ class _ScriptedLLM:
         timeout_seconds: float | None = None,
         max_tokens: int | None = None,
     ) -> Any:
-        del schema, max_tokens
+        del schema
         self.calls += 1
         self.prompts.append(prompt)
         self.timeouts.append(timeout_seconds)
+        self.token_limits.append(max_tokens)
         if not self._responses:
             raise RuntimeError("InstructorRetryException")
         item = self._responses.pop(0)
@@ -175,6 +177,8 @@ async def test_compile_skips_failed_chunk_and_keeps_later_terms() -> None:
     result = await compile_ontology_from_shots(shots=shots, llm=llm, prompt_path=_PROMPT)
     assert "python" in result.materialized.positive_skills
     assert result.materialized.negative_roles or result.materialized.anti_patterns
+    assert llm.token_limits[:2] == [12000, 12000]
+    assert llm.token_limits[2:] == [12000, 12000]
 
 
 @pytest.mark.asyncio

--- a/tests/application/test_run_report_html.py
+++ b/tests/application/test_run_report_html.py
@@ -1,0 +1,47 @@
+import pytest
+
+from job_ftch.adapters.telegram_bot.main import _send_scheduler_run_report
+from job_ftch.application.run_report import build_runtime_run_report, render_runtime_run_report_text
+
+
+def test_runtime_report_escapes_dynamic_html() -> None:
+    summary = type(
+        "Summary",
+        (),
+        {"source_failures": [{"source_name": '<future> & "jobs"', "error": "bad <tag> & timeout"}]},
+    )()
+
+    text = render_runtime_run_report_text(build_runtime_run_report(summary, duration_seconds=1))
+
+    assert "<future>" not in text
+    assert "&lt;future&gt; &amp; &quot;jobs&quot;" in text
+    assert "bad &lt;tag&gt; &amp; timeout" in text
+
+
+@pytest.mark.asyncio
+async def test_scheduler_owner_report_failure_is_persisted_without_raising() -> None:
+    class Store:
+        def __init__(self) -> None:
+            self.state: dict[str, str] = {}
+
+        async def set_run_state(self, key: str, value: str) -> None:
+            self.state[key] = value
+
+    class Bot:
+        async def send_message(self, *_: object, **__: object) -> None:
+            raise RuntimeError('bad <future> & "source"')
+
+    store = Store()
+    await _send_scheduler_run_report(
+        Bot(),
+        store=store,
+        tenant_id="ai_jobs",
+        publish_user_id="42",
+        run_result=type("Summary", (), {})(),
+        duration_seconds=1,
+        channel_sent=3,
+    )
+
+    assert store.state["bot_scheduler:last_owner_report_attempt_at"]
+    assert store.state["bot_scheduler:last_owner_report_error"] == 'bad <future> & "source"'
+    assert "bot_scheduler:last_owner_report_success_at" not in store.state

--- a/tests/test_aggregator_board_parsers.py
+++ b/tests/test_aggregator_board_parsers.py
@@ -169,6 +169,33 @@ async def test_agilefluent_uses_api_rows_without_following_origin() -> None:
 
 
 @pytest.mark.asyncio
+async def test_agilefluent_keeps_paging_past_five_pages() -> None:
+    class Client:
+        def __init__(self) -> None:
+            self.pages: list[int] = []
+
+        async def post(self, url: str, *, json: dict[str, object], **_: object) -> _JsonResponse:
+            page = int(json["pagination"]["page"])  # type: ignore[index]
+            self.pages.append(page)
+            row = {"id": page, "title": "Backend Engineer", "description": "Backend"}
+            if page == 6:
+                row = {"id": page, "title": "AI Engineer", "description": "Full AI role"}
+            return _JsonResponse("", url, payload={"data": [row], "hasMore": page < 6})
+
+    client = Client()
+    spec = CareerSiteSpec(
+        url="https://jobboard.agilefluent.ru/",
+        limit=1,
+        monitor_config={"_search_keywords": ["AI Engineer"]},
+    )
+
+    items = [item async for item in AgileFluentParser().parse(spec, client)]
+
+    assert client.pages == [1, 2, 3, 4, 5, 6]
+    assert [item.external_id for item in items] == ["6"]
+
+
+@pytest.mark.asyncio
 async def test_foorilla_parses_htmx_job_cards() -> None:
     listing = """
     <li class="list-group-item">

--- a/tests/test_hh_site_parser.py
+++ b/tests/test_hh_site_parser.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 
 import pytest
 
-import job_ftch.infrastructure.sources.site_parsers.hh as hh_module
 from job_ftch.domain.source_spec import CareerSiteSpec
 from job_ftch.infrastructure.sources.site_parsers.hh import (
     HhParser,
@@ -210,8 +209,7 @@ async def test_hh_parser_routes_detail_captcha_to_bypass() -> None:
 
 
 @pytest.mark.asyncio
-async def test_hh_parser_caps_detail_requests(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(hh_module, "_MAX_DETAIL_REQUESTS", 1)
+async def test_hh_parser_respects_configured_detail_limit() -> None:
     listing_url = "https://hh.ru/search/vacancy?text=ai"
     first_url = "https://hh.ru/vacancy/1"
     second_url = "https://hh.ru/vacancy/2"
@@ -230,7 +228,7 @@ async def test_hh_parser_caps_detail_requests(monkeypatch: pytest.MonkeyPatch) -
     items = [
         item
         async for item in HhParser().parse(
-            CareerSiteSpec(url=listing_url, source_name="hh", limit=2), client
+            CareerSiteSpec(url=listing_url, source_name="hh", limit=2, detail_limit=1), client
         )
     ]
 

--- a/tests/test_hirehi_site_parser.py
+++ b/tests/test_hirehi_site_parser.py
@@ -10,6 +10,17 @@ from job_ftch.infrastructure.sources.site_parsers.hirehi import HireHiParser
 
 class _Client:
     async def get(self, url: str, **_: object) -> SimpleNamespace:
+        if "/development/" in url:
+            return SimpleNamespace(
+                url=url,
+                text=(
+                    '<script type="application/ld+json">'
+                    '{"@type":"JobPosting","title":"AI Engineer",'
+                    '"description":"<p>Build production AI systems.</p>"}'
+                    "</script>"
+                ),
+                raise_for_status=lambda: None,
+            )
         return SimpleNamespace(
             url=url,
             text=(
@@ -35,3 +46,4 @@ async def test_hirehi_parser_reads_current_json_ld_listing() -> None:
 
     assert len(items) == 1
     assert str(items[0].url) == "https://hirehi.ru/development/ai-engineer-in-banking-87396"
+    assert "Build production AI systems." in items[0].text

--- a/tests/test_hirify_site_parser.py
+++ b/tests/test_hirify_site_parser.py
@@ -154,6 +154,32 @@ async def test_body_comes_from_the_per_vacancy_endpoint() -> None:
 
 
 @pytest.mark.asyncio
+async def test_listing_api_paginates_until_limit() -> None:
+    class Client(_ApiClient):
+        def __init__(self) -> None:
+            super().__init__()
+            self.pages: list[str] = []
+
+        async def get(self, url: str, **kwargs: object) -> object:
+            if url.endswith("/api/vacancies"):
+                page = str(kwargs.get("params", {}).get("page"))  # type: ignore[union-attr]
+                self.pages.append(page)
+                row = {**_LISTING_ROW, "id": 668117 + int(page), "slug": f"role-{page}"}
+                return _JsonResponse(
+                    {"data": [row], "next_page_url": "next" if page == "1" else None}, url
+                )
+            return await super().get(url, **kwargs)
+
+    client = Client()
+    spec = _spec().model_copy(update={"limit": 2})
+
+    items = [item async for item in HirifyParser().parse(spec, client)]
+
+    assert client.pages == ["1", "2"]
+    assert len(items) == 2
+
+
+@pytest.mark.asyncio
 async def test_search_api_still_runs_when_listing_page_is_unavailable() -> None:
     class _ApiOnlyClient(_ApiClient):
         async def get(self, url: str, **kwargs: object) -> object:

--- a/tests/test_site_parser_repairs.py
+++ b/tests/test_site_parser_repairs.py
@@ -11,6 +11,7 @@ from job_ftch.infrastructure.sources.monitors.greenhouse import can_handle as gr
 from job_ftch.infrastructure.sources.monitors.lever import can_handle as lever_can_handle
 from job_ftch.infrastructure.sources.site_parsers.geekjob import GeekJobParser
 from job_ftch.infrastructure.sources.site_parsers.habr import HabrCareerParser
+from job_ftch.infrastructure.sources.site_parsers.kaspi import KaspiParser
 from job_ftch.infrastructure.sources.site_parsers.rabota import RabotaByParser
 from job_ftch.infrastructure.sources.site_parsers.sber import SberParser, _sber_slug
 from job_ftch.infrastructure.sources.site_parsers.tbank import (
@@ -205,7 +206,7 @@ async def test_geekjob_parser_emits_json_rows_without_browser() -> None:
 
 
 @pytest.mark.asyncio
-async def test_habr_parser_emits_listing_cards_without_detail_fetch() -> None:
+async def test_habr_parser_fetches_full_detail() -> None:
     parser = HabrCareerParser()
     client = _FakeClient(
         {
@@ -213,7 +214,14 @@ async def test_habr_parser_emits_listing_cards_without_detail_fetch() -> None:
                 '<a class="vacancy-card__title-link" href="/vacancies/1000160764">'
                 "Продуктовый аналитик</a>",
                 "https://career.habr.com/companies/rwb/vacancies",
-            )
+            ),
+            "https://career.habr.com/vacancies/1000160764": _FakeResponse(
+                '<script type="application/ld+json">'
+                '{"@type":"JobPosting","title":"Продуктовый аналитик",'
+                '"description":"<p>Полное описание обязанностей вакансии.</p>"}'
+                "</script>",
+                "https://career.habr.com/vacancies/1000160764",
+            ),
         }
     )
     items = [
@@ -229,7 +237,34 @@ async def test_habr_parser_emits_listing_cards_without_detail_fetch() -> None:
     ]
     assert len(items) == 1
     assert items[0].external_id == "1000160764"
-    assert "Продуктовый аналитик" in items[0].text
+    assert "Полное описание обязанностей вакансии." in items[0].text
+    assert items[0].metadata["detail_vacancy_confirmed"] is True
+
+
+@pytest.mark.asyncio
+async def test_kaspi_parser_enriches_listing_from_jobposting_detail() -> None:
+    listing_url = "https://job.kaspi.kz/search"
+    detail_url = "https://job.kaspi.kz/vacancy/ai-engineer"
+    client = _FakeClient(
+        {
+            listing_url: _FakeResponse(
+                '<a href="/vacancy/ai-engineer">AI Engineer</a>', listing_url
+            ),
+            detail_url: _FakeResponse(
+                '<script type="application/ld+json">'
+                '{"@type":"JobPosting","description":"<p>Полные требования вакансии.</p>"}'
+                "</script>",
+                detail_url,
+            ),
+        }
+    )
+
+    items = [
+        item async for item in KaspiParser().parse(CareerSiteSpec(url=listing_url, limit=1), client)
+    ]
+
+    assert "Полные требования вакансии." in items[0].text
+    assert items[0].metadata["detail_vacancy_confirmed"] is True
 
 
 @pytest.mark.asyncio
@@ -469,6 +504,32 @@ async def test_vk_parser_uses_public_api_and_preserves_search_query() -> None:
         "https://team.vk.company/vacancy/52146/",
         "https://team.vk.company/vacancy/51999/",
     ]
+
+
+@pytest.mark.asyncio
+async def test_vk_parser_reads_full_detail_article() -> None:
+    api_url = "https://team.vk.company/career/api/v2/vacancies/?limit=50&offset=0"
+    detail_url = "https://team.vk.company/vacancy/52146/"
+    client = _FakeClient(
+        {
+            api_url: _FakeResponse('{"results": [{"id": 52146}]}', api_url),
+            detail_url: _FakeResponse(
+                '<div class="article"><h1>AI Engineer</h1><p>Полное описание задач и требований.</p></div>',
+                detail_url,
+            ),
+        }
+    )
+
+    items = [
+        item
+        async for item in VkTeamParser().parse(
+            CareerSiteSpec(url="https://team.vk.company/vacancy/", limit=1), client
+        )
+    ]
+
+    assert len(items) == 1
+    assert "Полное описание задач и требований." in items[0].text
+    assert items[0].metadata["detail_vacancy_confirmed"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_yandex_site_parser.py
+++ b/tests/test_yandex_site_parser.py
@@ -217,3 +217,39 @@ async def test_yandex_parser_prefers_http_publications_api() -> None:
     assert len(items) == 1
     assert items[0].external_id == "15322"
     assert "LLM" in items[0].text
+
+
+@pytest.mark.asyncio
+async def test_yandex_parser_passes_runtime_search_keywords_to_api() -> None:
+    parser = YandexJobsParser()
+    client = _FakeClient(
+        {
+            "https://yandex.ru/jobs/api/publications?page_size=1&text=LLM+Engineer": _FakeResponse(
+                "",
+                "https://yandex.ru/jobs/api/publications?page_size=1&text=LLM+Engineer",
+                payload={
+                    "results": [
+                        {
+                            "id": 42,
+                            "title": "LLM Engineer",
+                            "publication_slug_url": "/jobs/vacancies/llm-engineer-42",
+                        }
+                    ]
+                },
+            )
+        }
+    )
+
+    items = [
+        item
+        async for item in parser.parse(
+            CareerSiteSpec(
+                url="https://yandex.ru/jobs/vacancies",
+                limit=1,
+                monitor_config={"_search_keywords": ["LLM Engineer"]},
+            ),
+            client,
+        )
+    ]
+
+    assert [item.external_id for item in items] == ["42"]


### PR DESCRIPTION
## Summary\n- harden HH/Habr/VK/Kaspi and aggregator parsers\n- preserve compiled ontology terms when reapplying staging\n- improve Telegram/API reporting and parser regression coverage\n\n## Verification\n- just tests-all: 3641 passed, 5 skipped, 7 deselected\n- just code-verify: passed\n- release-contract: 59 passed; classification/extraction gates passed\n- docs build --strict: passed\n- ai-repo-safety scan/prepush: passed\n- controlled eval: P=0.844, R=0.704, F1=0.768\n\nNo production deploy is part of this PR; deploy follows after CI and merge.